### PR TITLE
Adding Cloud Run Service Log tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Deploy from agent SDKs, like the [Google Gen AI SDK](https://ai.google.dev/gemin
 - `deploy-file-contents`: Deploys files to Cloud Run by providing their contents directly.
 - `list-services`: Lists Cloud Run services in a given project and region.
 - `get-service`: Gets details for a specific Cloud Run service.
+- `get-service-log`: Gets Logs and Error Messages for a specific Cloud Run service.
 - `deploy-local-files`*: Deploys files from the local file system to a Google Cloud Run service.
 - `deploy-local-folder`*: Deploys a local folder to a Google Cloud Run service.
 - `list-projects`*: Lists available GCP projects.

--- a/lib/cloud-run-services.js
+++ b/lib/cloud-run-services.js
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import protofiles from 'google-proto-files'
+
 let runClient;
+let loggingClient;
 
 /**
  * Lists all Cloud Run services in a given project and location.
@@ -70,4 +73,73 @@ export async function getService(projectId, location, serviceId) {
     }
     throw error; // Re-throw other errors
   }
+}
+
+/**
+ * Fetches logs for a specific Cloud Run service.
+ * @param {string} projectId - The Google Cloud project ID.
+ * @param {string} location - The Google Cloud location (e.g., 'europe-west1').
+ * @param {string} serviceId - The ID of the Cloud Run service.
+ * @returns {Promise<Array<object>>} - A promise that resolves to an array of log entry objects.
+ */
+export async function getServiceLogs(projectId, location, serviceId) {
+  if (!loggingClient) {
+    const { Logging } = await import('@google-cloud/logging');
+    loggingClient = new Logging({ projectId });
+  }
+
+  try {
+    const LOG_SEVERITY = 'DEFAULT'; // e.g., 'DEFAULT', 'INFO', 'WARNING', 'ERROR'
+    const PAGE_SIZE = 50;       // Number of log entries to retrieve
+
+    const filter = `resource.type="cloud_run_revision"
+                    resource.labels.service_name="${serviceId}"
+                    resource.labels.location="${location}"
+                    severity>=${LOG_SEVERITY}`;
+
+    console.log(`Getting details for Cloud Run service ${serviceId} in project ${projectId}, location ${location}...`);
+
+    const [entries] = await loggingClient.getEntries({
+      filter: filter,
+      orderBy: 'timestamp desc', // Get the latest logs first
+      pageSize: PAGE_SIZE,
+    });
+
+    // return entries; // Original return
+    const formattedLogLines = entries.map(entry => formatLogEntry(entry)).join('\n');
+    return formattedLogLines
+  } catch (error) {
+    console.error(`Error fetching logs for Cloud Run service ${serviceId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Formats a single log entry for display.
+ * @param {object} entry - A log entry object from the Cloud Logging API.
+ * @returns {string} - A formatted string representation of the log entry.
+ */
+function formatLogEntry(entry) {
+  const timestampStr = entry.metadata.timestamp.toISOString() || 'N/A';
+  const severity = entry.metadata.severity || 'N/A';
+  let responseData = ''
+  if (entry.metadata.httpRequest) {
+    const responseMethod = entry.metadata.httpRequest.requestMethod;
+    const responseCode = entry.metadata.httpRequest.status;
+    const requestUrl = entry.metadata.httpRequest.requestUrl;
+    const responseSize = entry.metadata.httpRequest.responseSize;
+    responseData = `HTTP Request: ${responseMethod} StatusCode: ${responseCode} ResponseSize: ${responseSize} Byte - ${requestUrl}`
+  }
+
+  let data = ''
+  if (entry.data && entry.data.value) {
+    const protopath = protofiles.getProtoPath('../google/cloud/audit/audit_log.proto')
+    const root = protofiles.loadSync(protopath)
+    const type = root.lookupType('google.cloud.audit.AuditLog')
+    const value = type.decode(entry.data.value)
+    data = `${value.methodName}: ${value.status?.message || ''}${value.authenticationInfo?.principalEmail || ''}`
+  } else if (entry.data) {
+    data = entry.data
+  }
+  return `[${timestampStr}] [${severity}] ${responseData} ${data}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/artifact-registry": "^4.0.1",
         "@google-cloud/billing": "^5.0.1",
         "@google-cloud/cloudbuild": "^5.0.1",
+        "@google-cloud/logging": "^11.2.0",
         "@google-cloud/resource-manager": "^6.0.1",
         "@google-cloud/run": "^2.0.1",
         "@google-cloud/service-usage": "^4.1.0",
@@ -19,6 +20,7 @@
         "@modelcontextprotocol/sdk": "^1.11.0",
         "archiver": "^7.0.1",
         "express": "^5.1.0",
+        "google-proto-files": "^4.2.0",
         "zod": "^3.24.4"
       },
       "bin": {
@@ -59,6 +61,107 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
+      "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "extend": "^3.0.2",
+        "google-auth-library": "^9.0.0",
+        "html-entities": "^2.5.2",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/logging": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-11.2.0.tgz",
+      "integrity": "sha512-Ma94jvuoMpbgNniwtelOt8w82hxK62FuOXZonEv0Hyk3B+/YVuLG/SWNyY9yMso/RXnPEc1fP2qo9kDrjf/b2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^5.0.0",
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "@opentelemetry/api": "^1.7.0",
+        "arrify": "^2.0.1",
+        "dot-prop": "^6.0.0",
+        "eventid": "^2.0.0",
+        "extend": "^3.0.2",
+        "gcp-metadata": "^6.0.0",
+        "google-auth-library": "^9.0.0",
+        "google-gax": "^4.0.3",
+        "on-finished": "^2.3.0",
+        "pumpify": "^2.0.1",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/logging/node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@google-cloud/logging/node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/logging/node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/logging/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -232,6 +335,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -928,6 +1040,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1089,6 +1216,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eventid/-/eventid-2.0.1.tgz",
+      "integrity": "sha512-sPNTqiMokAvV048P2c9+foqVJzk49o6d4e0D/sq5jog3pw+4kBgyR0gaM1FM7Mx6Kzd9dztesh9oYz1LWWOpzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/events": {
@@ -1660,6 +1799,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/google-proto-files": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-4.2.0.tgz",
+      "integrity": "sha512-Yl3ZtTSpkOLjHTqHn91NhDp2jMPzpHWowSGz3S30N6gkqOXrJwUu44alR9dX+NyHK3n165uR+jezOH365b1pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "walkdir": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1852,6 +2004,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2341,6 +2502,27 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
       }
     },
     "node_modules/qs": {
@@ -2950,6 +3132,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@google-cloud/artifact-registry": "^4.0.1",
     "@google-cloud/billing": "^5.0.1",
     "@google-cloud/cloudbuild": "^5.0.1",
+    "@google-cloud/logging": "^11.2.0",
     "@google-cloud/resource-manager": "^6.0.1",
     "@google-cloud/run": "^2.0.1",
     "@google-cloud/service-usage": "^4.1.0",
@@ -38,6 +39,7 @@
     "@modelcontextprotocol/sdk": "^1.11.0",
     "archiver": "^7.0.1",
     "express": "^5.1.0",
+    "google-proto-files": "^4.2.0",
     "zod": "^3.24.4"
   }
 }

--- a/tools.js
+++ b/tools.js
@@ -16,9 +16,10 @@ limitations under the License.
 
 import { z } from "zod";
 import { deploy } from './lib/cloud-run-deploy.js';
-import { listServices, getService } from './lib/cloud-run-services.js';
+import { listServices, getService, getServiceLogs } from './lib/cloud-run-services.js';
 import { listProjects, createProjectAndAttachBilling } from './lib/gcp-projects.js';
 import { checkGCP } from './lib/gcp-metadata.js';
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export const registerTools = (server) => {
   // Tool to list GCP projects
@@ -154,6 +155,36 @@ export const registerTools = (server) => {
           content: [{
             type: 'text',
             text: `Error getting service ${service} in project ${project} (region ${region}): ${error.message}`
+          }]
+        };
+      }
+    }
+  );
+
+  // Logs for a service
+  server.tool(
+    "get_service_log",
+    "Gets Logs and Error Messages for a specific Cloud Run service.",
+    {
+      project: z.string().describe("Google Cloud project ID containing the service"),
+      region: z.string().describe("Region where the service is located").default('europe-west1'),
+      service: z.string().describe("Name of the Cloud Run service"),
+    },
+    async ({ project, region, service }) => {
+      try {
+        console.log("teste")
+        const logs = await getServiceLogs(project, region, service);
+        return {
+          content: [{
+            type: 'text',
+            text: logs
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Error getting Logs for service ${service} in project ${project} (region ${region}): ${error.message}`
           }]
         };
       }
@@ -394,6 +425,36 @@ export const registerToolsRemote = async (server) => {
     }
   );
 
+  // Logs for a service
+  server.tool(
+    "get_service_log",
+    "Gets Logs and Error Messages for a specific Cloud Run service.",
+    {
+      project: z.string().describe("Google Cloud project ID containing the service"),
+      region: z.string().describe("Region where the service is located").default('europe-west1'),
+      service: z.string().describe("Name of the Cloud Run service"),
+    },
+    async ({ project, region, service }) => {
+      try {
+        console.log("teste")
+        const logs = await getServiceLogs(project, region, service);
+        return {
+          content: [{
+            type: 'text',
+            text: logs
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Error getting Logs for service ${service} in project ${project} (region ${region}): ${error.message}`
+          }]
+        };
+      }
+    }
+  );
+
   // Deploy file contents to Cloud Run (Remote)
   server.tool(
     'deploy_file_contents',
@@ -446,5 +507,5 @@ export const registerToolsRemote = async (server) => {
           ],
         };
       }
-  });
+    });
 };


### PR DESCRIPTION
Adding a tool to retreive and query Logs for a Cloud Run service . 

Example:

CStanger:
get me the error logs for hello.

GitHub Copilot:
Here are the recent logs for the "hello" Cloud Run service in region europe-west4, project myspace-cstanger:

The service is running normally, serving HTTP GET requests with status code 200 (success) for various assets and the main page.
There are no error logs present. The most recent log entries show successful requests and a service update event by user cstanger.
The service's "Ready" condition was set to True, indicating it is healthy and available.
If you need logs for a different time period or want to filter for errors only, let me know!