### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Enable MCP-compatible AI agents to deploy apps to Cloud Run.
 
+<a href="https://glama.ai/mcp/servers/@GoogleCloudPlatform/cloud-run-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GoogleCloudPlatform/cloud-run-mcp/badge" alt="Cloud Run Server MCP server" />
+</a>
+
 ```json
 "mcpServers":{
   "cloud-run": {


### PR DESCRIPTION
This PR adds a badge for the [Cloud Run MCP Server](https://glama.ai/mcp/servers/@GoogleCloudPlatform/cloud-run-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@GoogleCloudPlatform/cloud-run-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GoogleCloudPlatform/cloud-run-mcp/badge" alt="Cloud Run Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.