### PR TITLE
no exit if auth check fails

### DIFF
--- a/lib/gcp-auth-check.js
+++ b/lib/gcp-auth-check.js
@@ -58,6 +58,6 @@ export async function ensureGCPCredentials() {
         if (error.stack) {
             console.error('Error stack:', error.stack);
         }
-        process.exit(1);
+        // process.exit(1);
     }
 }


### PR DESCRIPTION
For stdio servers, users can recover from this situation by logging in. So it could be useful for the server to stay running and deliver instructions on how to resolve the error.