### PR TITLE
feat: add test to confirm mcp server exposes expected tools and prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
   "bin": "mcp-server.js",
   "scripts": {
     "deploy": "gcloud run deploy cloud-run-mcp --source . --no-invoker-iam-check",
-    "test:mcp": "npx @modelcontextprotocol/inspector node mcp-server.js",
     "test:deploy": "node test/test-deploy.js",
     "test:create-project": "node test/test-create-project.js",
     "test:service-logs": "node test/test-service-logs.js",
     "test:gcp-auth": "node test/test-gcp-auth.js",
     "test:prompts": "node --test test/test-prompts.js",
+    "test:mcp": "node test/test-mcp-server.js",
+    "mcp-inspector": "npx @modelcontextprotocol/inspector node mcp-server.js",
     "test": "node test/run-all-tests.js",
     "start": "node mcp-server.js"
   },

--- a/test/test-mcp-server.js
+++ b/test/test-mcp-server.js
@@ -1,0 +1,53 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+describe('MCP Server in stdio mode', () => {
+  let client;
+  let transport;
+
+  before(async () => {
+    transport = new StdioClientTransport({
+      command: 'node',
+      args: ['mcp-server.js']
+    });
+    client = new Client({ 
+      name: 'test-client',
+      version: '1.0.0'
+    });
+    await client.connect(transport);
+  });
+
+  after(() => {
+    client.close();
+  });
+
+  test('should list tools', async () => {
+    const response = await client.listTools();
+
+    const tools = response.tools;
+    assert(Array.isArray(tools));
+    const toolNames = tools.map(t => t.name);
+    assert.deepStrictEqual(toolNames.sort(), [
+      'create_project',
+      'deploy_container_image',
+      'deploy_file_contents',
+      'deploy_local_files',
+      'deploy_local_folder',
+      'get_service',
+      'get_service_log',
+      'list_projects',
+      'list_services'
+    ].sort());
+  });
+
+  test('should list prompts', async () => {
+    const response = await client.listPrompts();
+
+    const prompts = response.prompts;
+    assert(Array.isArray(prompts));
+    const promptNames = prompts.map(p => p.name);
+    assert.deepStrictEqual(promptNames.sort(), ['deploy', 'logs'].sort());
+  });
+});


### PR DESCRIPTION
This test starts the MCP server and uses the StdioClientTransport to connect to it and check that the expected tools and prompts are exposed. Fixes #49