### PR TITLE
feat: add gemini-cli extension instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,17 @@ See Docker's [MCP catalog](https://hub.docker.com/mcp/server/cloud-run-mcp/overv
       }
    ```
 
+## Use as a `gemini-cli` extension
+
+To install this as a `gemini-cli` extension, run the following command:
+
+```bash
+mkdir -p ~/.gemini/extensions/cloud-run && \
+  curl -s -L https://raw.githubusercontent.com/GoogleCloudPlatform/cloud-run-mcp/main/gemini-extension.json > ~/.gemini/extensions/cloud-run/gemini-extension.json
+```
+
 ## Use as remote MCP server
+
 
 > [!WARNING]  
 > Do not use the remote MCP server without authentication. In the following instructions, we will use IAM authentication to secure the connection to the MCP server from your local machine. This is important to prevent unauthorized access to your Google Cloud resources.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,10 @@
+{
+  "name": "cloud-run",
+  "version": "1.0.0",
+  "mcpServers": {
+    "cloud-run": {
+      "command": "npx",
+      "args": ["-y", "https://github.com/GoogleCloudPlatform/cloud-run-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds instructions for installing the cloud-run-mcp tool as a gemini-cli extension. It also adds the necessary gemini-extension.json file.

Fixes #60