### PR TITLE
Update package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloud-run-mcp",
+  "name": "@google-cloud/cloud-run-mcp",
   "version": "1.0.0",
   "type": "module",
   "description": "Cloud Run MCP deployment tool",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "description": "Cloud Run MCP deployment tool",
   "main": "mcp-server.js",
-  "bin": "mcp-server.js",
+  "bin": {
+    "cloud-run-mcp": "mcp-server.js"
+  },
   "scripts": {
     "deploy": "gcloud run deploy cloud-run-mcp --source . --no-invoker-iam-check",
     "test:deploy": "node test/test-deploy.js",


### PR DESCRIPTION
This was made to prepare publication on NPM: https://www.npmjs.com/package/@google-cloud/cloud-run-mcp

A side effect is that the `bin` attribute now needs a specific `cloud-run-mcp` name.