### PR TITLE
feat: Add retry logic for API enablement

### DIFF
--- a/lib/cloud-run-deploy.js
+++ b/lib/cloud-run-deploy.js
@@ -64,8 +64,39 @@ function logAndProgress(message, progressCallback, severity = 'info') {
 }
 
 /**
+ * Checks if a single Google Cloud API is enabled and enables it if not.
+ *
+ * @param {object} serviceUsageClient - The Service Usage client.
+ * @param {string} serviceName - The full name of the service (e.g., 'projects/my-project/services/run.googleapis.com').
+ * @param {string} api - The API identifier (e.g., 'run.googleapis.com').
+ * @param {function(string, string=): void} progressCallback - A function to call with progress updates.
+ * @returns {Promise<void>} A promise that resolves when the API is enabled.
+ * @throws {Error} If the API fails to enable or if there's an issue checking its status.
+ */
+async function checkAndEnableApi(
+  serviceUsageClient,
+  serviceName,
+  api,
+  progressCallback
+) {
+  const [service] = await serviceUsageClient.getService({
+    name: serviceName,
+  });
+  if (service.state !== 'ENABLED') {
+    logAndProgress(
+      `API [${api}] is not enabled. Enabling...`,
+      progressCallback
+    );
+    const [operation] = await serviceUsageClient.enableService({
+      name: serviceName,
+    });
+    await operation.promise();
+  }
+}
+
+/**
  * Ensures that the specified Google Cloud APIs are enabled for the given project.
- * If an API is not enabled, it attempts to enable it.
+ * If an API is not enabled, it attempts to enable it.  Retries any failure once after 1s.
  * Throws an error if an API cannot be enabled.
  *
  * @async
@@ -84,24 +115,34 @@ async function ensureApisEnabled(projectId, apis, progressCallback) {
   for (const api of apis) {
     const serviceName = `projects/${projectId}/services/${api}`;
     try {
-      const [service] = await serviceUsageClient.getService({
-        name: serviceName,
-      });
-      if (service.state !== 'ENABLED') {
-        logAndProgress(
-          `API [${api}] is not enabled. Enabling...`,
+      await checkAndEnableApi(
+        serviceUsageClient,
+        serviceName,
+        api,
+        progressCallback
+      );
+    } catch (error) {
+      // First attempt failed, log a warning and retry once after a delay.
+      logAndProgress(
+        `Failed to check/enable ${api}, retrying in 1s...`,
+        progressCallback,
+        'warn'
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      try {
+        await checkAndEnableApi(
+          serviceUsageClient,
+          serviceName,
+          api,
           progressCallback
         );
-        const [operation] = await serviceUsageClient.enableService({
-          name: serviceName,
-        });
-        await operation.promise();
+      } catch (retryError) {
+        // If the retry also fails, throw an error.
+        const errorMessage = `Failed to ensure API [${api}] is enabled after retry. Please check manually.`;
+        console.error(errorMessage, retryError);
+        logAndProgress(errorMessage, progressCallback, 'error');
+        throw new Error(errorMessage);
       }
-    } catch (error) {
-      const errorMessage = `Failed to ensure API [${api}] is enabled. Please check manually.`;
-      console.error(errorMessage, error);
-      logAndProgress(errorMessage, progressCallback, 'error');
-      throw new Error(errorMessage);
     }
   }
   logAndProgress('All required APIs are enabled.', progressCallback);


### PR DESCRIPTION
This commit introduces a retry mechanism to the `ensureApisEnabled` function in `lib/cloud-run-deploy.js`. This makes the API enablement check more resilient to intermittent failures.  Addresses #77 and #52 