### PR TITLE
feat: Add service account support for deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@
 
 # Node.js
 node_modules/
+
 .gemini/
+.vscode/

--- a/lib/cloud-run-deploy.js
+++ b/lib/cloud-run-deploy.js
@@ -209,7 +209,8 @@ async function deployToCloudRun(
   serviceId,
   imgUrl,
   progressCallback,
-  skipIamCheck
+  skipIamCheck,
+  serviceAccount
 ) {
   const parent = runClient.locationPath(projectId, location);
   const servicePath = runClient.servicePath(projectId, location, serviceId);
@@ -219,6 +220,7 @@ async function deployToCloudRun(
     template: {
       revision: revisionName,
       containers: [{ image: imgUrl }],
+      ...(serviceAccount && { serviceAccount: serviceAccount }),
     },
     labels: {
       'created-by': 'cloud-run-mcp',
@@ -764,6 +766,7 @@ export async function deploy({
   files,
   progressCallback,
   skipIamCheck,
+  serviceAccount,
 }) {
   if (!projectId) {
     const errorMsg =
@@ -888,7 +891,8 @@ export async function deploy({
       serviceName,
       builtImageUrl,
       progressCallback,
-      skipIamCheck
+      skipIamCheck,
+      serviceAccount
     );
 
     logAndProgress(`Deployment Completed Successfully`, progressCallback);
@@ -920,6 +924,7 @@ export async function deployImage({
   imageUrl,
   progressCallback,
   skipIamCheck,
+  serviceAccount,
 }) {
   if (!projectId) {
     const errorMsg =
@@ -961,7 +966,8 @@ export async function deployImage({
       serviceName,
       imageUrl,
       progressCallback,
-      skipIamCheck
+      skipIamCheck,
+      serviceAccount
     );
 
     logAndProgress(`Deployment Completed Successfully`, progressCallback);

--- a/prompts.js
+++ b/prompts.js
@@ -33,14 +33,21 @@ export const registerPrompts = (server) => {
           .string()
           .describe('Region where the services are located')
           .optional(),
+        serviceAccount: z
+          .string()
+          .optional()
+          .describe('Email of the service account to use for the deployment.'),
       },
     },
-    async ({ name, project, region }) => {
+    async ({ name, project, region, serviceAccount }) => {
       const serviceNamePrompt =
         name ||
         'a name for the application based on the current working directory.';
       const projectPrompt = project ? ` in project ${project}` : '';
       const regionPrompt = region ? ` in region ${region}` : '';
+      const saPrompt = serviceAccount
+        ? ` with the service account ${serviceAccount}`
+        : '';
 
       return {
         messages: [
@@ -48,7 +55,7 @@ export const registerPrompts = (server) => {
             role: 'user',
             content: {
               type: 'text',
-              text: `Use the deploy_local_folder tool to deploy the current folder${projectPrompt}${regionPrompt}. The service name should be ${serviceNamePrompt}`,
+              text: `Use the deploy_local_folder tool to deploy the current folder${projectPrompt}${regionPrompt}${saPrompt}. The service name should be ${serviceNamePrompt}`,
             },
           },
         ],

--- a/tools.js
+++ b/tools.js
@@ -417,23 +417,23 @@ export const registerTools = (
             'Google Cloud project ID. Do not select it yourself, make sure the user provides or confirms the project ID.'
           )
           .default(defaultProjectId),
-        region:
-          z.string()
+        region: z
+          .string()
           .optional()
           .default(defaultRegion)
           .describe('Region to deploy the service to'),
-        service:
-          z.string()
+        service: z
+          .string()
           .optional()
           .default(defaultServiceName)
           .describe('Name of the Cloud Run service to deploy to'),
-        folderPath:
-          z.string()
+        folderPath: z
+          .string()
           .describe(
             'Absolute path to the folder to deploy (e.g. "/home/user/project/src")'
           ),
-        serviceAccount:
-          z.string()
+        serviceAccount: z
+          .string()
           .optional()
           .describe('Email of the service account to attach to the service.'),
       },
@@ -496,24 +496,35 @@ export const registerTools = (
             'Google Cloud project ID. Leave unset for the app to be deployed in a new project. If provided, make sure the user confirms the project ID they want to deploy to.'
           )
           .default(defaultProjectId),
-        region:
-          z.string().optional().default(defaultRegion).describe('Region to deploy the service to'),
-        service:
-          z.string().optional().default(defaultServiceName).describe('Name of the Cloud Run service to deploy to'),
-        files:
-          z.array(
+        region: z
+          .string()
+          .optional()
+          .default(defaultRegion)
+          .describe('Region to deploy the service to'),
+        service: z
+          .string()
+          .optional()
+          .default(defaultServiceName)
+          .describe('Name of the Cloud Run service to deploy to'),
+        files: z
+          .array(
             z.object({
-              filename:
-                z.string().describe(
+              filename: z
+                .string()
+                .describe(
                   'Name and path of the file (e.g. "src/index.js" or "data/config.json")'
                 ),
-              content:
-                z.string().optional().describe('Text content of the file'),
+              content: z
+                .string()
+                .optional()
+                .describe('Text content of the file'),
             })
           )
           .describe('Array of file objects containing filename and content'),
-        serviceAccount:
-          z.string().optional().describe('Email of the service account to attach to the service.'),
+        serviceAccount: z
+          .string()
+          .optional()
+          .describe('Email of the service account to attach to the service.'),
       },
     },
     gcpTool(
@@ -877,7 +888,7 @@ export const registerToolsRemote = async (
       gcpCredentialsAvailable,
       async ({ region, service, files, serviceAccount }) => {
         console.log(
-          `New deploy request (remote): ${JSON.stringify({ project: currentProject, region, service, files }) }`
+          `New deploy request (remote): ${JSON.stringify({ project: currentProject, region, service, files })}`
         );
 
         if (
@@ -932,7 +943,7 @@ Service URL: ${response.uri}`,
   server.registerTool(
     'deploy_container_image',
     {
-      description: `Deploys a container image to Cloud Run in the GCP project ${currentProject}. Use this tool if the user provides a container image URL.`, 
+      description: `Deploys a container image to Cloud Run in the GCP project ${currentProject}. Use this tool if the user provides a container image URL.`,
       inputSchema: {
         region: z
           .string()


### PR DESCRIPTION
Adding support for service accounts. See https://github.com/GoogleCloudPlatform/cloud-run-mcp/issues/65 

In this PR:

- added support for specifying name of service account to be used
- added new unit test for the service account name
- updated .gitignore file to ignore .vscode configurations

Verified the following:

- a valid service account
- no service account mentioned (it used the default compute SA as expected)
- telling gemini to "use the default service account" (it used the default compute SA as expected)
- and with an invalid service account (got appropriate error message from gemini)