### PR TITLE
Fix publish to npm GH Action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,8 +12,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://wombat-dressing-room.appspot.com/
       - run: npm ci
+      # Now configure with the publish service for install.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://wombat-dressing-room.appspot.com/
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}


### PR DESCRIPTION
`registry-url` should only be set for `npm publish``