### PR TITLE
Fix project creation

### DIFF
--- a/lib/gcp-projects.js
+++ b/lib/gcp-projects.js
@@ -72,7 +72,7 @@ export async function createProject(projectId) {
   }
 
   try {
-    const projectPayload = { projectId: projectIdToUse, name: projectIdToUse };
+    const projectPayload = { projectId: projectIdToUse };
 
     console.log(`Attempting to create project with ID: ${projectIdToUse}`);
 


### PR DESCRIPTION
We were getting:

> Error creating GCP project or attaching billing: Failed to create project: 3    INVALID_ARGUMENT: field [project.name] has issue [field should not be set for new projects]       
