### PR TITLE
Add retry logic to API calls.

### DIFF
--- a/lib/cloud-run-deploy.js
+++ b/lib/cloud-run-deploy.js
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { callWithRetry, ensureApisEnabled } from './gcp-api-helpers.js';
+
 // Configuration
 const REPO_NAME = 'mcp-cloud-run-deployments';
 const ZIP_FILE_NAME = 'source.zip';
@@ -64,91 +66,6 @@ function logAndProgress(message, progressCallback, severity = 'info') {
 }
 
 /**
- * Checks if a single Google Cloud API is enabled and enables it if not.
- *
- * @param {object} serviceUsageClient - The Service Usage client.
- * @param {string} serviceName - The full name of the service (e.g., 'projects/my-project/services/run.googleapis.com').
- * @param {string} api - The API identifier (e.g., 'run.googleapis.com').
- * @param {function(string, string=): void} progressCallback - A function to call with progress updates.
- * @returns {Promise<void>} A promise that resolves when the API is enabled.
- * @throws {Error} If the API fails to enable or if there's an issue checking its status.
- */
-async function checkAndEnableApi(
-  serviceUsageClient,
-  serviceName,
-  api,
-  progressCallback
-) {
-  const [service] = await serviceUsageClient.getService({
-    name: serviceName,
-  });
-  if (service.state !== 'ENABLED') {
-    logAndProgress(
-      `API [${api}] is not enabled. Enabling...`,
-      progressCallback
-    );
-    const [operation] = await serviceUsageClient.enableService({
-      name: serviceName,
-    });
-    await operation.promise();
-  }
-}
-
-/**
- * Ensures that the specified Google Cloud APIs are enabled for the given project.
- * If an API is not enabled, it attempts to enable it.  Retries any failure once after 1s.
- * Throws an error if an API cannot be enabled.
- *
- * @async
- * @param {string} projectId - The Google Cloud project ID.
- * @param {string[]} apis - An array of API identifiers to check and enable (e.g., 'run.googleapis.com').
- * @param {function(string, string=): void} progressCallback - A function to call with progress updates.
- * The first argument is the message, the optional second argument is the type ('error', 'warning', 'info').
- * @throws {Error} If an API fails to enable or if there's an issue checking its status.
- * @returns {Promise<void>} A promise that resolves when all specified APIs are enabled.
- */
-async function ensureApisEnabled(projectId, apis, progressCallback) {
-  const { ServiceUsageClient } = await import('@google-cloud/service-usage');
-  const serviceUsageClient = new ServiceUsageClient({ projectId });
-  logAndProgress('Checking and enabling required APIs...', progressCallback);
-
-  for (const api of apis) {
-    const serviceName = `projects/${projectId}/services/${api}`;
-    try {
-      await checkAndEnableApi(
-        serviceUsageClient,
-        serviceName,
-        api,
-        progressCallback
-      );
-    } catch (error) {
-      // First attempt failed, log a warning and retry once after a delay.
-      logAndProgress(
-        `Failed to check/enable ${api}, retrying in 1s...`,
-        progressCallback,
-        'warn'
-      );
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      try {
-        await checkAndEnableApi(
-          serviceUsageClient,
-          serviceName,
-          api,
-          progressCallback
-        );
-      } catch (retryError) {
-        // If the retry also fails, throw an error.
-        const errorMessage = `Failed to ensure API [${api}] is enabled after retry. Please check manually.`;
-        console.error(errorMessage, retryError);
-        logAndProgress(errorMessage, progressCallback, 'error');
-        throw new Error(errorMessage);
-      }
-    }
-  }
-  logAndProgress('All required APIs are enabled.', progressCallback);
-}
-
-/**
  * Checks if a Cloud Run service already exists.
  *
  * @async
@@ -168,7 +85,10 @@ async function checkCloudRunServiceExists(
   const parent = runClient.locationPath(projectId, location);
   const servicePath = runClient.servicePath(projectId, location, serviceId);
   try {
-    await runClient.getService({ name: servicePath });
+    await callWithRetry(
+      () => runClient.getService({ name: servicePath }),
+      `getService ${serviceId}`
+    );
     logAndProgress(
       `Cloud Run service ${serviceId} already exists.`,
       progressCallback
@@ -249,17 +169,25 @@ async function deployToCloudRun(
 
       if (exists) {
         dryRunServiceConfig.name = servicePath;
-        await runClient.updateService({
-          service: dryRunServiceConfig,
-          validateOnly: true,
-        });
+        await callWithRetry(
+          () =>
+            runClient.updateService({
+              service: dryRunServiceConfig,
+              validateOnly: true,
+            }),
+          `updateService (dry run) ${serviceId}`
+        );
       } else {
-        await runClient.createService({
-          parent: parent,
-          service: dryRunServiceConfig,
-          serviceId: serviceId,
-          validateOnly: true,
-        });
+        await callWithRetry(
+          () =>
+            runClient.createService({
+              parent: parent,
+              service: dryRunServiceConfig,
+              serviceId: serviceId,
+              validateOnly: true,
+            }),
+          `createService (dry run) ${serviceId}`
+        );
       }
       logAndProgress(
         `Dry run successful for ${serviceId} with current configuration.`,
@@ -302,14 +230,21 @@ async function deployToCloudRun(
         progressCallback
       );
       service.name = servicePath;
-      [operation] = await runClient.updateService({ service });
+      [operation] = await callWithRetry(
+        () => runClient.updateService({ service }),
+        `updateService ${serviceId}`
+      );
     } else {
       logAndProgress(`Creating new service ${serviceId}...`, progressCallback);
-      [operation] = await runClient.createService({
-        parent: parent,
-        service: service, // 'service' object might have invokerIamDisabled removed
-        serviceId: serviceId,
-      });
+      [operation] = await callWithRetry(
+        () =>
+          runClient.createService({
+            parent: parent,
+            service: service, // 'service' object might have invokerIamDisabled removed
+            serviceId: serviceId,
+          }),
+        `createService ${serviceId}`
+      );
     }
 
     logAndProgress(`Deploying ${serviceId} to Cloud Run...`, progressCallback);
@@ -346,7 +281,10 @@ async function ensureStorageBucketExists(
 ) {
   const bucket = storage.bucket(bucketName);
   try {
-    const [exists] = await bucket.exists();
+    const [exists] = await callWithRetry(
+      () => bucket.exists(),
+      `storage.bucket.exists ${bucketName}`
+    );
     if (exists) {
       logAndProgress(`Bucket ${bucketName} already exists.`, progressCallback);
       return bucket;
@@ -356,9 +294,10 @@ async function ensureStorageBucketExists(
         progressCallback
       );
       try {
-        const [createdBucket] = await storage.createBucket(bucketName, {
-          location: location,
-        });
+        const [createdBucket] = await callWithRetry(
+          () => storage.createBucket(bucketName, { location: location }),
+          `storage.createBucket ${bucketName}`
+        );
         logAndProgress(
           `Storage bucket ${createdBucket.name} created successfully in ${location}.`,
           progressCallback
@@ -482,7 +421,10 @@ async function uploadToStorageBucket(
       `Uploading buffer to gs://${bucket.name}/${destinationBlobName}...`,
       progressCallback
     );
-    await bucket.file(destinationBlobName).save(buffer);
+    await callWithRetry(
+      () => bucket.file(destinationBlobName).save(buffer),
+      `storage.bucket.file.save ${destinationBlobName}`
+    );
     logAndProgress(
       `File ${destinationBlobName} uploaded successfully to gs://${bucket.name}/${destinationBlobName}.`,
       progressCallback
@@ -524,9 +466,10 @@ async function ensureArtifactRegistryRepoExists(
   );
 
   try {
-    const [repository] = await artifactRegistryClient.getRepository({
-      name: repoPath,
-    });
+    const [repository] = await callWithRetry(
+      () => artifactRegistryClient.getRepository({ name: repoPath }),
+      `artifactRegistry.getRepository ${repositoryId}`
+    );
     logAndProgress(
       `Repository ${repositoryId} already exists in ${location}.`,
       progressCallback
@@ -541,46 +484,26 @@ async function ensureArtifactRegistryRepoExists(
       const repositoryToCreate = {
         format: format,
       };
-      const maxRetries = 3;
-      const retryDelay = 10000; // 10s
 
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-          const [operation] = await artifactRegistryClient.createRepository({
+      const [operation] = await callWithRetry(
+        () =>
+          artifactRegistryClient.createRepository({
             parent: parent,
             repository: repositoryToCreate,
             repositoryId: repositoryId,
-          });
-          logAndProgress(
-            `Creating Artifact Registry repository ${repositoryId}...`,
-            progressCallback
-          );
-          const [result] = await operation.promise();
-          logAndProgress(
-            `Artifact Registry repository ${result.name} created successfully.`,
-            progressCallback
-          );
-          return result;
-        } catch (createError) {
-          // PERMISSION_DENIED is code 7 for gRPC. Retry on this error.
-          if (createError.code === 7 && attempt < maxRetries) {
-            logAndProgress(
-              `Attempt ${attempt} to create repository failed. This can happen on new projects. Retrying in 10s...`,
-              progressCallback,
-              'warn'
-            );
-            await new Promise((resolve) => setTimeout(resolve, retryDelay));
-          } else {
-            const errorMessage = `Failed to create Artifact Registry repository ${repositoryId}. Error details: ${createError.message}`;
-            console.error(
-              `Failed to create Artifact Registry repository ${repositoryId}. Error details:`,
-              createError
-            );
-            logAndProgress(errorMessage, progressCallback, 'error');
-            throw createError;
-          }
-        }
-      }
+          }),
+        `artifactRegistry.createRepository ${repositoryId}`
+      );
+      logAndProgress(
+        `Creating Artifact Registry repository ${repositoryId}...`,
+        progressCallback
+      );
+      const [result] = await operation.promise();
+      logAndProgress(
+        `Artifact Registry repository ${result.name} created successfully.`,
+        progressCallback
+      );
+      return result;
     } else {
       const errorMessage = `Error checking/creating repository ${repositoryId}: ${error.message}`;
       console.error(
@@ -661,19 +584,19 @@ async function triggerCloudBuild(
     `Initiating Cloud Build for gs://${sourceBucketName}/${sourceBlobName} in ${location}...`,
     progressCallback
   );
-  const [operation] = await cloudBuildClient.createBuild({
-    projectId: projectId,
-    build: build,
-  });
+  const [operation] = await callWithRetry(
+    () => cloudBuildClient.createBuild({ projectId: projectId, build: build }),
+    'cloudBuild.createBuild'
+  );
 
   logAndProgress(`Cloud Build job started...`, progressCallback);
   const buildId = operation.metadata.build.id;
   let completedBuild;
   while (true) {
-    const [getBuildOperation] = await cloudBuildClient.getBuild({
-      projectId: projectId,
-      id: buildId,
-    });
+    const [getBuildOperation] = await callWithRetry(
+      () => cloudBuildClient.getBuild({ projectId: projectId, id: buildId }),
+      `cloudBuild.getBuild ${buildId}`
+    );
     if (
       ['SUCCESS', 'FAILURE', 'INTERNAL_ERROR', 'TIMEOUT', 'CANCELLED'].includes(
         getBuildOperation.status
@@ -724,11 +647,15 @@ async function triggerCloudBuild(
       );
 
       // Fetch the most recent N log entries
-      const [entries] = await loggingClient.getEntries({
-        filter: logFilter,
-        orderBy: 'timestamp desc', // Get latest logs first
-        pageSize: BUILD_LOGS_LINES_TO_FETCH,
-      });
+      const [entries] = await callWithRetry(
+        () =>
+          loggingClient.getEntries({
+            filter: logFilter,
+            orderBy: 'timestamp desc', // Get latest logs first
+            pageSize: BUILD_LOGS_LINES_TO_FETCH,
+          }),
+        `logging.getEntries for build ${buildId}`
+      );
 
       if (entries && entries.length > 0) {
         // Entries are newest first, reverse for chronological order of the snippet

--- a/lib/cloud-run-services.js
+++ b/lib/cloud-run-services.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import protofiles from 'google-proto-files';
+import { callWithRetry, ensureApisEnabled } from './gcp-api-helpers.js';
 
 let runClient;
 let loggingClient;
@@ -32,13 +33,19 @@ export async function listServices(projectId, location) {
     const { ServicesClient } = v2;
     runClient = new ServicesClient({ projectId });
   }
+
+  await ensureApisEnabled(projectId, ['run.googleapis.com']);
+
   const parent = runClient.locationPath(projectId, location);
 
   try {
     console.log(
       `Listing Cloud Run services in project ${projectId}, location ${location}...`
     );
-    const [services] = await runClient.listServices({ parent });
+    const [services] = await callWithRetry(
+      () => runClient.listServices({ parent }),
+      'listServices'
+    );
     return services;
   } catch (error) {
     console.error(`Error listing Cloud Run services:`, error);
@@ -66,7 +73,10 @@ export async function getService(projectId, location, serviceId) {
     console.log(
       `Getting details for Cloud Run service ${serviceId} in project ${projectId}, location ${location}...`
     );
-    const [service] = await runClient.getService({ name: servicePath });
+    const [service] = await callWithRetry(
+      () => runClient.getService({ name: servicePath }),
+      'getService'
+    );
     return service;
   } catch (error) {
     console.error(
@@ -123,8 +133,10 @@ export async function getServiceLogs(
     console.log(`Request options: ${JSON.stringify(options)}`);
 
     // getEntries returns the entries and the full API response
-    const [entries, nextRequestOptions, apiResponse] =
-      await loggingClient.getEntries(options);
+    const [entries, nextRequestOptions, apiResponse] = await callWithRetry(
+      () => loggingClient.getEntries(options),
+      'getEntries'
+    );
 
     const formattedLogLines = entries
       .map((entry) => formatLogEntry(entry))

--- a/lib/gcp-api-helpers.js
+++ b/lib/gcp-api-helpers.js
@@ -1,0 +1,143 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Calls a function with retry logic for GCP API calls.
+ * Retries on gRPC error code 7 (PERMISSION_DENIED).
+ * @param {Function} fn The function to call.
+ * @param {string} description A description of the function being called, for logging.
+ * @returns {Promise<any>} The result of the function.
+ */
+export async function callWithRetry(fn, description) {
+  const maxRetries = 10;
+  const initialBackoff = 1000; // 1 second
+  let retries = 0;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (error.code === 7 && retries < maxRetries) {
+        retries++;
+        let backoff;
+        if (retries === 1) {
+          backoff = 10000; // 10 seconds for the first retry
+        } else {
+          backoff = initialBackoff * Math.pow(2, retries - 2);
+        }
+        console.warn(
+          `API call "${description}" failed with PERMISSION_DENIED. Retrying in ${
+            backoff / 1000
+          }s... (attempt ${retries}/${maxRetries})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+      } else {
+        throw error;
+      }
+    }
+  }
+}
+
+/**
+ * Checks if a single Google Cloud API is enabled and enables it if not.
+ *
+ * @param {object} serviceUsageClient - The Service Usage client.
+ * @param {string} serviceName - The full name of the service (e.g., 'projects/my-project/services/run.googleapis.com').
+ * @param {string} api - The API identifier (e.g., 'run.googleapis.com').
+ * @param {function(string, string=): void} progressCallback - A function to call with progress updates.
+ * @returns {Promise<void>} A promise that resolves when the API is enabled.
+ * @throws {Error} If the API fails to enable or if there's an issue checking its status.
+ */
+async function checkAndEnableApi(
+  serviceUsageClient,
+  serviceName,
+  api,
+  progressCallback
+) {
+  const [service] = await callWithRetry(
+    () => serviceUsageClient.getService({ name: serviceName }),
+    `getService ${api}`
+  );
+  if (service.state !== 'ENABLED') {
+    const message = `API [${api}] is not enabled. Enabling...`;
+    console.log(message);
+    if (progressCallback) progressCallback({ level: 'info', data: message });
+
+    const [operation] = await callWithRetry(
+      () => serviceUsageClient.enableService({ name: serviceName }),
+      `enableService ${api}`
+    );
+    await operation.promise();
+  }
+}
+
+/**
+ * Ensures that the specified Google Cloud APIs are enabled for the given project.
+ * If an API is not enabled, it attempts to enable it.  Retries any failure once after 1s.
+ * Throws an error if an API cannot be enabled.
+ *
+ * @async
+ * @param {string} projectId - The Google Cloud project ID.
+ * @param {string[]} apis - An array of API identifiers to check and enable (e.g., 'run.googleapis.com').
+ * @param {function(string, string=): void} progressCallback - A function to call with progress updates.
+ * The first argument is the message, the optional second argument is the type ('error', 'warning', 'info').
+ * @throws {Error} If an API fails to enable or if there's an issue checking its status.
+ * @returns {Promise<void>} A promise that resolves when all specified APIs are enabled.
+ */
+export async function ensureApisEnabled(projectId, apis, progressCallback) {
+  const { ServiceUsageClient } = await import('@google-cloud/service-usage');
+  const serviceUsageClient = new ServiceUsageClient({ projectId });
+  const message = 'Checking and enabling required APIs...';
+  console.log(message);
+  if (progressCallback) progressCallback({ level: 'info', data: message });
+
+
+  for (const api of apis) {
+    const serviceName = `projects/${projectId}/services/${api}`;
+    try {
+      await checkAndEnableApi(
+        serviceUsageClient,
+        serviceName,
+        api,
+        progressCallback
+      );
+    } catch (error) {
+      // First attempt failed, log a warning and retry once after a delay.
+      const warnMsg = `Failed to check/enable ${api}, retrying in 1s...`;
+      console.warn(warnMsg);
+      if (progressCallback) progressCallback({ level: 'warn', data: warnMsg });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      try {
+        await checkAndEnableApi(
+          serviceUsageClient,
+          serviceName,
+          api,
+          progressCallback
+        );
+      } catch (retryError) {
+        // If the retry also fails, throw an error.
+        const errorMessage = `Failed to ensure API [${api}] is enabled after retry. Please check manually.`;
+        console.error(errorMessage, retryError);
+        if (progressCallback) progressCallback({ level: 'error', data: errorMessage });
+        throw new Error(errorMessage);
+      }
+    }
+  }
+  const successMsg = 'All required APIs are enabled.';
+  console.log(successMsg);
+  if (progressCallback) progressCallback({ level: 'info', data: successMsg });
+}

--- a/lib/gcp-api-helpers.js
+++ b/lib/gcp-api-helpers.js
@@ -22,7 +22,7 @@ limitations under the License.
  * @returns {Promise<any>} The result of the function.
  */
 export async function callWithRetry(fn, description) {
-  const maxRetries = 10;
+  const maxRetries = 7;
   const initialBackoff = 1000; // 1 second
   let retries = 0;
 
@@ -34,7 +34,7 @@ export async function callWithRetry(fn, description) {
         retries++;
         let backoff;
         if (retries === 1) {
-          backoff = 10000; // 10 seconds for the first retry
+          backoff = 15000; // 15 seconds for the first retry
         } else {
           backoff = initialBackoff * Math.pow(2, retries - 2);
         }


### PR DESCRIPTION
To mitigate IAM propagation errors.
For deploy and services libs (other don't need it)

Also added API enablement check on services lib (re-factored the logic out of deploy lib)

Confirmed it improved first deployment in new project, I see this in my logs now: 

```
Creating Artifact Registry repository mcp-cloud-run-deployments... 
Artifact Registry repository projects/mcp-zon-xid/locations/europe-west1/repositories/mcp-cloud-run-deployments created successfully. 
Initiating Cloud Build for gs://mcp-zon-xid-source-bucket/source.zip in europe-west1... 
API call "cloudBuild.createBuild" failed with PERMISSION_DENIED. 
Retrying in 10s... (attempt 1/10) API call "cloudBuild.createBuild" failed with PERMISSION_DENIED. 
Retrying in 1s... (attempt 2/10) API call "cloudBuild.createBuild" failed with PERMISSION_DENIED. 
Retrying in 2s... (attempt 3/10) API call "cloudBuild.createBuild" failed with PERMISSION_DENIED. 
Retrying in 4s... (attempt 4/10) API call "cloudBuild.createBuild" failed with PERMISSION_DENIED. 
Retrying in 8s... (attempt 5/10) Cloud Build job started...
Build status: WORKING. Waiting...
Build status: WORKING. Waiting...
```