### PR TITLE
feat: Refactor file archiving and deployment logic

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -1,0 +1,165 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { logAndProgress } from './logging.js';
+import path from 'path';
+import fs from 'fs';
+import archiver from 'archiver';
+
+export async function prepareFileMap(files, progressCallback) {
+  const fileMap = {};
+  let commonBaseDir = '';
+
+  // Determine the type of input and find the common base directory
+  if (files.every((file) => typeof file === 'string')) {
+    // This handles `deploy_local_files` and `deploy_local_folder`.
+    // For `deploy_local_folder`, the input is a single directory path.
+    // For `deploy_local_files`, the input is an array of file and/or directory paths.
+
+    const filePaths = files.map((file) => {
+      let pathInput = file;
+      // This is a "hack" to better support WSL on Windows.
+      if (pathInput.startsWith('/c')) {
+        pathInput = `/mnt${pathInput}`;
+      }
+      return path.resolve(pathInput);
+    });
+
+    if (filePaths.length > 0) {
+      if (filePaths.length === 1 && fs.statSync(filePaths[0]).isDirectory()) {
+        // Case: `deploy_local_folder` - The base directory is the folder path provided.
+        commonBaseDir = filePaths[0];
+      } else {
+        // Case: `deploy_local_files` - The base directory is the lowest common parent directory.
+        const firstPathParts = filePaths[0].split(path.sep);
+        commonBaseDir = firstPathParts
+          .slice(
+            0,
+            firstPathParts.length - (fs.statSync(filePaths[0]).isDirectory() ? 0 : 1)
+          )
+          .join(path.sep);
+
+        for (let i = 1; i < filePaths.length; i++) {
+          const currentPath = filePaths[i];
+          while (!currentPath.startsWith(commonBaseDir)) {
+            commonBaseDir = path.dirname(commonBaseDir);
+          }
+        }
+      }
+    }
+  } else if (files.every((file) => typeof file === 'object' && 'filename' in file && 'content' in file)) {
+    // Case: `deploy_file_contents` - The base directory is the root of the virtual file system.
+    commonBaseDir = '';
+  }
+
+  async function addFileToMap(filePath) {
+    let pathInput = filePath;
+    if (pathInput.startsWith('/c')) {
+      pathInput = `/mnt${pathInput}`;
+    }
+    const resolvedPath = path.resolve(pathInput);
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`File or directory not found: ${resolvedPath}`);
+    }
+
+    const stats = fs.statSync(resolvedPath);
+    if (stats.isDirectory()) {
+      const items = fs.readdirSync(resolvedPath);
+      for (const item of items) {
+        await addFileToMap(path.join(resolvedPath, item));
+      }
+    } else {
+      const relativePath = path.relative(commonBaseDir, resolvedPath);
+      fileMap[relativePath] = { sourcePath: resolvedPath };
+    }
+  }
+
+  for (const file of files) {
+    if (typeof file === 'string') {
+      await addFileToMap(file);
+    } else if (
+      typeof file === 'object' &&
+      'filename' in file &&
+      'content' in file
+    ) {
+      fileMap[file.filename] = { content: file.content };
+    } else {
+      throw new Error(`Invalid file format: ${JSON.stringify(file)}`);
+    }
+  }
+
+  return fileMap;
+}
+
+export async function createArchive(fileMap, progressCallback) {
+  const archive = archiver('zip', {
+    zlib: { level: 9 },
+  });
+
+  archive.on('warning', (err) => {
+    const warningMessage = `Archiver warning: ${err}`;
+    logAndProgress(warningMessage, progressCallback, 'warn');
+  });
+
+  archive.on('error', (err) => {
+    const errorMessage = `Archiver error: ${err.message}`;
+    console.error(errorMessage, err);
+    logAndProgress(errorMessage, progressCallback, 'error');
+    throw err;
+  });
+
+  for (const [destinationPath, fileInfo] of Object.entries(fileMap)) {
+    if (fileInfo.sourcePath) {
+      archive.file(fileInfo.sourcePath, { name: destinationPath });
+    } else if (fileInfo.content) {
+      archive.append(fileInfo.content, { name: destinationPath });
+    }
+  }
+
+  return archive;
+}
+
+async function getArchiveBuffer(archive) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    archive.on('data', (chunk) => chunks.push(chunk));
+    archive.on('end', () => resolve(Buffer.concat(chunks)));
+    archive.on('error', reject);
+    archive.finalize();
+  });
+}
+
+export async function zipFiles(files, progressCallback) {
+  logAndProgress('Preparing file map...', progressCallback);
+  const fileMap = await prepareFileMap(files, progressCallback);
+
+  logAndProgress('Creating zip archive...', progressCallback);
+  const archive = await createArchive(fileMap, progressCallback);
+
+  logAndProgress('Buffering zip archive...', progressCallback);
+  const zipBuffer = await getArchiveBuffer(archive);
+
+  logAndProgress(
+    `Files zipped successfully. Total size: ${zipBuffer.length} bytes`,
+    progressCallback
+  );
+
+  const hasDockerfile = Object.keys(fileMap).some(
+    (name) => name.toLowerCase() === 'dockerfile'
+  );
+
+  return { zipBuffer, hasDockerfile };
+}

--- a/lib/cloud-run-deploy.js
+++ b/lib/cloud-run-deploy.js
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 import { callWithRetry, ensureApisEnabled } from './gcp-api-helpers.js';
+import { zipFiles } from './archive.js';
+import { logAndProgress } from './logging.js';
 
 // Configuration
 const REPO_NAME = 'mcp-cloud-run-deployments';
@@ -41,29 +43,6 @@ let storage;
 let cloudBuildClient;
 let artifactRegistryClient;
 let runClient;
-
-/**
- * Helper function to log a message and call the progress callback.
- * @param {string} message - The message to log.
- * @param {function(object): void} [progressCallback] - Optional callback for progress updates.
- * @param {'debug' | 'info' | 'warn' | 'error'} [severity='info'] - The severity level of the message.
- */
-async function logAndProgress(message, progressCallback, severity = 'info') {
-  switch (severity) {
-    case 'error':
-      console.error(message);
-      break;
-    case 'warn':
-    case 'info':
-    case 'debug':
-    default:
-      console.log(message);
-      break;
-  }
-  if (progressCallback) {
-    progressCallback({ level: severity, data: message });
-  }
-}
 
 /**
  * Checks if a Cloud Run service already exists.
@@ -327,83 +306,7 @@ async function ensureStorageBucketExists(
   }
 }
 
-/**
- * Creates a zip archive in memory from a list of file paths and/or file objects.
- * File objects should have `filename` (string) and `content` (Buffer or string) properties.
- *
- * @param {Array<string|{filename: string, content: Buffer|string}>} files - An array of items to zip.
- * Each item can be a string representing a file/directory path, or an object
- * with `filename` and `content` properties for in-memory files.
- * @param {function(object): void} [progressCallback] - Optional callback for progress updates.
- * @returns {Promise<Buffer>} A promise that resolves with a Buffer containing the zip data.
- * @throws {Error} If an input file path is not found, an input item has an invalid format, or an archiver error occurs.
- */
-async function zipFiles(files, progressCallback) {
-  const path = await import('path');
-  const fs = await import('fs');
-  const archiver = (await import('archiver')).default;
 
-  return new Promise((resolve, reject) => {
-    logAndProgress('Creating in-memory zip archive...', progressCallback);
-    const chunks = [];
-    const archive = archiver('zip', {
-      zlib: { level: 9 },
-    });
-
-    archive.on('data', (chunk) => chunks.push(chunk));
-    archive.on('end', () => {
-      logAndProgress(
-        `Files zipped successfully. Total size: ${archive.pointer()} bytes`,
-        progressCallback
-      );
-      resolve(Buffer.concat(chunks));
-    });
-
-    archive.on('warning', (err) => {
-      const warningMessage = `Archiver warning: ${err}`;
-      logAndProgress(warningMessage, progressCallback, 'warn');
-      if (err.code !== 'ENOENT') {
-        // ENOENT is often just a warning, others might be more critical for zip
-        reject(err);
-      }
-    });
-
-    archive.on('error', (err) => {
-      const errorMessage = `Archiver error: ${err.message}`;
-      console.error(errorMessage, err);
-      logAndProgress(errorMessage, progressCallback, 'error');
-      reject(err);
-    });
-
-    files.forEach((file) => {
-      if (typeof file === 'object' && 'filename' in file && 'content' in file) {
-        archive.append(file.content, { name: file.filename });
-      } else if (typeof file === 'string') {
-        let pathInput = file;
-
-        // This is a "hack" to better support WSL on Windows. AI agents tend to send path that start with '/c' in that case. Re-write it to '/mnt/c'
-        if (pathInput.startsWith('/c')) {
-          pathInput = `/mnt${pathInput}`;
-        }
-        const filePath = path.resolve(pathInput);
-        if (!fs.existsSync(filePath)) {
-          throw new Error(`File or directory not found: ${filePath}`);
-        }
-
-        const stats = fs.statSync(filePath);
-        if (stats.isDirectory()) {
-          archive.directory(filePath, false);
-        } else {
-          archive.file(filePath, { name: path.basename(filePath) });
-        }
-      } else {
-        throw new Error(`Invalid file format: ${JSON.stringify(file)}`);
-      }
-    });
-
-    archive.finalize();
-  });
-}
 
 /**
  * Uploads a buffer to a specified Google Cloud Storage bucket and blob name.
@@ -709,7 +612,8 @@ export async function deploy({
   projectId,
   serviceName,
   region,
-  files,
+  zipBuffer,
+  hasDockerfile,
   progressCallback,
   skipIamCheck,
 }) {
@@ -720,19 +624,8 @@ export async function deploy({
     process.exit(1);
   }
 
-  if (!files || !Array.isArray(files) || files.length === 0) {
-    const errorMsg =
-      'Error: files array is required in the configuration object.';
-    await logAndProgress(errorMsg, progressCallback, 'error');
-    if (typeof process !== 'undefined' && process.exit) {
-      process.exit(1);
-    } else {
-      throw new Error(errorMsg);
-    }
-  }
+  
 
-  const path = await import('path');
-  const fs = await import('fs');
   const { Storage } = await import('@google-cloud/storage');
   const { CloudBuildClient } = await import('@google-cloud/cloudbuild');
   const { ArtifactRegistryClient } = await import(
@@ -759,39 +652,9 @@ export async function deploy({
     await logAndProgress(`Project: ${projectId}`, progressCallback);
     await logAndProgress(`Region: ${region}`, progressCallback);
     await logAndProgress(`Service Name: ${serviceName}`, progressCallback);
-    await logAndProgress(`Files to deploy: ${files.length}`, progressCallback);
+    
 
-    let hasDockerfile = false;
-    if (
-      files.length === 1 &&
-      typeof files[0] === 'string' &&
-      fs.statSync(files[0]).isDirectory()
-    ) {
-      // Handle folder deployment: check for Dockerfile inside the folder
-      const dockerfilePath = path.join(files[0], 'Dockerfile');
-      const dockerfilePathLowerCase = path.join(files[0], 'dockerfile');
-      if (
-        fs.existsSync(dockerfilePath) ||
-        fs.existsSync(dockerfilePathLowerCase)
-      ) {
-        hasDockerfile = true;
-      }
-    } else {
-      // Handle file list deployment or file content deployment
-      for (const file of files) {
-        if (typeof file === 'string') {
-          if (path.basename(file).toLowerCase() === 'dockerfile') {
-            hasDockerfile = true;
-            break;
-          }
-        } else if (typeof file === 'object' && file.filename) {
-          if (path.basename(file.filename).toLowerCase() === 'dockerfile') {
-            hasDockerfile = true;
-            break;
-          }
-        }
-      }
-    }
+    
     await logAndProgress(`Dockerfile: ${hasDockerfile}`, progressCallback);
 
     const bucket = await ensureStorageBucketExists(
@@ -800,7 +663,6 @@ export async function deploy({
       progressCallback
     );
 
-    const zipBuffer = await zipFiles(files, progressCallback);
     await uploadToStorageBucket(
       bucket,
       zipBuffer,

--- a/lib/gcp-api-helpers.js
+++ b/lib/gcp-api-helpers.js
@@ -141,3 +141,5 @@ export async function ensureApisEnabled(projectId, apis, progressCallback) {
   console.log(successMsg);
   if (progressCallback) progressCallback({ level: 'info', data: successMsg });
 }
+
+import { logAndProgress } from './logging.js';

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Helper function to log a message and call the progress callback.
+ * @param {string} message - The message to log.
+ * @param {function(object): void} [progressCallback] - Optional callback for progress updates.
+ * @param {'debug' | 'info' | 'warn' | 'error'} [severity='info'] - The severity level of the message.
+ */
+export async function logAndProgress(message, progressCallback, severity = 'info') {
+  switch (severity) {
+    case 'error':
+      console.error(message);
+      break;
+    case 'warn':
+    case 'info':
+    case 'debug':
+    default:
+      console.log(message);
+      break;
+  }
+  if (progressCallback) {
+    progressCallback({ level: severity, data: message });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "esmock": "^2.7.1",
+        "mock-fs": "^5.5.0",
         "prettier": "3.6.2"
       }
     },
@@ -2276,6 +2277,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mock-fs": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
+      "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "esmock": "^2.7.1",
+    "mock-fs": "^5.5.0",
     "prettier": "3.6.2"
   }
 }

--- a/test/local/archive.test.js
+++ b/test/local/archive.test.js
@@ -1,0 +1,261 @@
+import { describe, it, afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { prepareFileMap, zipFiles } from '../../lib/archive.js';
+import mock from 'mock-fs';
+import esmock from 'esmock';
+
+describe('archive', () => {
+  describe('prepareFileMap', () => {
+    afterEach(() => {
+      mock.restore();
+    });
+
+    describe('when deploying local files', () => {
+      it('should handle a flat list of files', async () => {
+        mock({
+          '/fake/dir': {
+            'index.js': 'console.log("hello")',
+            'package.json': '{ "name": "my-app" }',
+          },
+        });
+
+        const fileMap = await prepareFileMap(['/fake/dir/index.js', '/fake/dir/package.json']);
+        assert.equal(Object.keys(fileMap).length, 2);
+        assert.ok(fileMap['index.js']);
+        assert.ok(fileMap['package.json']);
+        assert.equal(fileMap['index.js'].sourcePath, '/fake/dir/index.js');
+        assert.equal(fileMap['package.json'].sourcePath, '/fake/dir/package.json');
+        assert.equal(fileMap['index.js'].content, undefined);
+        assert.equal(fileMap['package.json'].content, undefined);
+      });
+
+      it('should handle a nested directory structure', async () => {
+        mock({
+          '/fake/dir': {
+            'src': {
+              'index.js': '',
+            },
+            'package.json': '',
+          },
+        });
+
+        const fileMap = await prepareFileMap(['/fake/dir/src/index.js', '/fake/dir/package.json']);
+        assert.equal(Object.keys(fileMap).length, 2);
+        assert.ok(fileMap['src/index.js']);
+        assert.ok(fileMap['package.json']);
+      });
+
+      it('should handle a mix of files and directories', async () => {
+        mock({
+          '/fake/dir': {
+            'src': {
+              'index.js': '',
+            },
+            'package.json': '',
+          },
+        });
+
+        const fileMap = await prepareFileMap(['/fake/dir/src', '/fake/dir/package.json']);
+        assert.equal(Object.keys(fileMap).length, 2);
+        assert.ok(fileMap['src/index.js']);
+        assert.ok(fileMap['package.json']);
+      });
+
+      it('should handle files with the same name in different directories', async () => {
+        mock({
+          '/fake/dir': {
+            'src': {
+              'index.js': '',
+            },
+            'lib': {
+              'index.js': '',
+            },
+          },
+        });
+
+        const fileMap = await prepareFileMap(['/fake/dir/src/index.js', '/fake/dir/lib/index.js']);
+        assert.equal(Object.keys(fileMap).length, 2);
+        assert.ok(fileMap['src/index.js']);
+        assert.ok(fileMap['lib/index.js']);
+      });
+
+      it('should handle WSL path transformations', async () => {
+        mock({
+          '/mnt/c/fake/dir': {
+            'index.js': '',
+          },
+        });
+
+        const fileMap = await prepareFileMap(['/c/fake/dir/index.js']);
+        assert.equal(Object.keys(fileMap).length, 1);
+        assert.ok(fileMap['index.js']);
+      });
+    });
+
+    describe('when deploying a local folder', () => {
+      it('should handle a single folder', async () => {
+        mock({
+          '/fake/dir': {
+            'index.js': 'console.log("hello")',
+            'package.json': '{ "name": "my-app" }',
+          },
+        });
+
+        const fileMap = await prepareFileMap(['/fake/dir']);
+        assert.equal(Object.keys(fileMap).length, 2);
+        assert.ok(fileMap['index.js']);
+        assert.ok(fileMap['package.json']);
+        assert.equal(fileMap['index.js'].sourcePath, '/fake/dir/index.js');
+        assert.equal(fileMap['package.json'].sourcePath, '/fake/dir/package.json');
+        assert.equal(fileMap['index.js'].content, undefined);
+        assert.equal(fileMap['package.json'].content, undefined);
+      });
+    });
+
+    describe('when deploying file contents', () => {
+      it('should handle a list of file objects', async () => {
+        const files = [
+          { filename: 'index.js', content: 'console.log("hello")' },
+          { filename: 'package.json', content: '{ "name": "my-app" }' },
+        ];
+
+        const fileMap = await prepareFileMap(files);
+        assert.equal(Object.keys(fileMap).length, 2);
+        assert.ok(fileMap['index.js']);
+        assert.ok(fileMap['package.json']);
+        assert.equal(fileMap['index.js'].content, 'console.log("hello")');
+        assert.equal(fileMap['package.json'].content, '{ "name": "my-app" }');
+        assert.equal(fileMap['index.js'].sourcePath, undefined);
+        assert.equal(fileMap['package.json'].sourcePath, undefined);
+      });
+    });
+  });
+
+  describe('createArchive', () => {
+    it('should call archiver.file for files with sourcePath', async () => {
+      const fileMap = {
+        'index.js': { sourcePath: '/fake/dir/index.js' },
+        'package.json': { sourcePath: '/fake/dir/package.json' },
+      };
+
+      const archiverMock = {
+        file: test.mock.fn(),
+        append: test.mock.fn(),
+        on: test.mock.fn(),
+      };
+
+      const archiverConstructorMock = test.mock.fn(() => archiverMock);
+
+      const { createArchive } = await esmock('../../lib/archive.js', {
+        archiver: archiverConstructorMock,
+      });
+
+      await createArchive(fileMap);
+
+      assert.equal(archiverConstructorMock.mock.callCount(), 1);
+      assert.equal(archiverMock.file.mock.callCount(), 2);
+      assert.equal(archiverMock.append.mock.callCount(), 0);
+      assert.deepStrictEqual(archiverMock.file.mock.calls[0].arguments, ['/fake/dir/index.js', { name: 'index.js' }]);
+      assert.deepStrictEqual(archiverMock.file.mock.calls[1].arguments, ['/fake/dir/package.json', { name: 'package.json' }]);
+    });
+
+    it('should call archiver.append for files with content', async () => {
+      const fileMap = {
+        'index.js': { content: 'console.log("hello")' },
+        'package.json': { content: '{ "name": "my-app" }' },
+      };
+
+      const archiverMock = {
+        file: test.mock.fn(),
+        append: test.mock.fn(),
+        on: test.mock.fn(),
+      };
+
+      const archiverConstructorMock = test.mock.fn(() => archiverMock);
+
+      const { createArchive } = await esmock('../../lib/archive.js', {
+        archiver: archiverConstructorMock,
+      });
+
+      await createArchive(fileMap);
+
+      assert.equal(archiverConstructorMock.mock.callCount(), 1);
+      assert.equal(archiverMock.file.mock.callCount(), 0);
+      assert.equal(archiverMock.append.mock.callCount(), 2);
+      assert.deepStrictEqual(archiverMock.append.mock.calls[0].arguments, ['console.log("hello")', { name: 'index.js' }]);
+      assert.deepStrictEqual(archiverMock.append.mock.calls[1].arguments, ['{ "name": "my-app" }', { name: 'package.json' }]);
+    });
+  });
+
+  describe('zipFiles', () => {
+    afterEach(() => {
+      mock.restore();
+    });
+
+    it('should throw an error if a file is not found', async () => {
+      mock({
+        '/fake/dir': {
+          'index.js': '',
+        },
+      });
+
+      await assert.rejects(
+        async () => {
+          await zipFiles(['/fake/dir/index.js', '/fake/dir/not-found.js']);
+        },
+        {
+          message: 'File or directory not found: /fake/dir/not-found.js',
+        }
+      );
+    });
+
+    it('should set hasDockerfile to true if Dockerfile is in the root', async () => {
+      mock({
+        '/fake/dir': {
+          'Dockerfile': '',
+          'index.js': '',
+        },
+      });
+
+      const { hasDockerfile } = await zipFiles(['/fake/dir/Dockerfile', '/fake/dir/index.js']);
+      assert.strictEqual(hasDockerfile, true);
+    });
+
+    it('should set hasDockerfile to true if dockerfile (lowercase) is in the root', async () => {
+      mock({
+        '/fake/dir': {
+          'dockerfile': '',
+          'index.js': '',
+        },
+      });
+
+      const { hasDockerfile } = await zipFiles(['/fake/dir/dockerfile', '/fake/dir/index.js']);
+      assert.strictEqual(hasDockerfile, true);
+    });
+
+    it('should set hasDockerfile to false if Dockerfile is in a subdirectory', async () => {
+      mock({
+        '/fake/dir': {
+          'src': {
+            'Dockerfile': '',
+          },
+          'index.js': '',
+        },
+      });
+
+      const { hasDockerfile } = await zipFiles(['/fake/dir/src/Dockerfile', '/fake/dir/index.js']);
+      assert.strictEqual(hasDockerfile, false);
+    });
+
+    it('should set hasDockerfile to false if there is no Dockerfile', async () => {
+      mock({
+        '/fake/dir': {
+          'index.js': '',
+        },
+      });
+
+      const { hasDockerfile } = await zipFiles(['/fake/dir/index.js']);
+      assert.strictEqual(hasDockerfile, false);
+    });
+  });
+});

--- a/test/local/notifications.test.js
+++ b/test/local/notifications.test.js
@@ -32,7 +32,7 @@ describe('Tool Notifications', () => {
       { sendNotification }
     );
 
-    assert.strictEqual(sendNotification.mock.callCount(), 1);
+    assert.strictEqual(sendNotification.mock.callCount(), 2);
     assert.deepStrictEqual(sendNotification.mock.calls[0].arguments[0], {
       method: 'notifications/message',
       params: {

--- a/test/local/tools.test.js
+++ b/test/local/tools.test.js
@@ -257,9 +257,14 @@ describe('registerTools', () => {
         registerTool: mock.fn(),
       };
 
+      const deployMock = mock.fn(() => Promise.resolve({ uri: 'my-uri' }));
+
       const { registerTools } = await esmock('../../tools.js', {
         '../../lib/cloud-run-deploy.js': {
-          deploy: () => Promise.resolve({ uri: 'my-uri' }),
+          deploy: deployMock,
+        },
+        '../../lib/archive.js': {
+          zipFiles: () => Promise.resolve({ zipBuffer: 'zip-buffer', hasDockerfile: true }),
         },
       });
 
@@ -286,6 +291,14 @@ describe('registerTools', () => {
           },
         ],
       });
+
+      assert.strictEqual(deployMock.mock.callCount(), 1);
+      const deployArgs = deployMock.mock.calls[0].arguments[0];
+      assert.strictEqual(deployArgs.projectId, 'my-project');
+      assert.strictEqual(deployArgs.serviceName, 'my-service');
+      assert.strictEqual(deployArgs.region, 'my-region');
+      assert.strictEqual(deployArgs.zipBuffer, 'zip-buffer');
+      assert.strictEqual(deployArgs.hasDockerfile, true);
     });
   });
 
@@ -295,9 +308,14 @@ describe('registerTools', () => {
         registerTool: mock.fn(),
       };
 
+      const deployMock = mock.fn(() => Promise.resolve({ uri: 'my-uri' }));
+
       const { registerTools } = await esmock('../../tools.js', {
         '../../lib/cloud-run-deploy.js': {
-          deploy: () => Promise.resolve({ uri: 'my-uri' }),
+          deploy: deployMock,
+        },
+        '../../lib/archive.js': {
+          zipFiles: () => Promise.resolve({ zipBuffer: 'zip-buffer', hasDockerfile: true }),
         },
       });
 
@@ -324,6 +342,14 @@ describe('registerTools', () => {
           },
         ],
       });
+
+      assert.strictEqual(deployMock.mock.callCount(), 1);
+      const deployArgs = deployMock.mock.calls[0].arguments[0];
+      assert.strictEqual(deployArgs.projectId, 'my-project');
+      assert.strictEqual(deployArgs.serviceName, 'my-service');
+      assert.strictEqual(deployArgs.region, 'my-region');
+      assert.strictEqual(deployArgs.zipBuffer, 'zip-buffer');
+      assert.strictEqual(deployArgs.hasDockerfile, true);
     });
   });
 
@@ -333,9 +359,14 @@ describe('registerTools', () => {
         registerTool: mock.fn(),
       };
 
+      const deployMock = mock.fn(() => Promise.resolve({ uri: 'my-uri' }));
+
       const { registerTools } = await esmock('../../tools.js', {
         '../../lib/cloud-run-deploy.js': {
-          deploy: () => Promise.resolve({ uri: 'my-uri' }),
+          deploy: deployMock,
+        },
+        '../../lib/archive.js': {
+          zipFiles: () => Promise.resolve({ zipBuffer: 'zip-buffer', hasDockerfile: true }),
         },
       });
 
@@ -362,6 +393,14 @@ describe('registerTools', () => {
           },
         ],
       });
+
+      assert.strictEqual(deployMock.mock.callCount(), 1);
+      const deployArgs = deployMock.mock.calls[0].arguments[0];
+      assert.strictEqual(deployArgs.projectId, 'my-project');
+      assert.strictEqual(deployArgs.serviceName, 'my-service');
+      assert.strictEqual(deployArgs.region, 'my-region');
+      assert.strictEqual(deployArgs.zipBuffer, 'zip-buffer');
+      assert.strictEqual(deployArgs.hasDockerfile, true);
     });
   });
 

--- a/tools.js
+++ b/tools.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { z } from 'zod';
 import { deploy, deployImage } from './lib/cloud-run-deploy.js';
+import { zipFiles } from './lib/archive.js';
 import {
   listServices,
   getService,
@@ -384,11 +385,18 @@ export const registerTools = (
           await progressCallback({
             data: `Starting deployment of local files for service ${service} in project ${project}...`,
           });
+
+          const { zipBuffer, hasDockerfile } = await zipFiles(
+            files,
+            progressCallback
+          );
+
           const response = await deploy({
             projectId: project,
             serviceName: service,
             region: region,
-            files: files,
+            zipBuffer,
+            hasDockerfile,
             skipIamCheck: skipIamCheck, // Pass the new flag
             progressCallback,
           });
@@ -467,11 +475,18 @@ export const registerTools = (
           await progressCallback({
             data: `Starting deployment of local folder for service ${service} in project ${project}...`,
           });
+
+          const { zipBuffer, hasDockerfile } = await zipFiles(
+            [folderPath],
+            progressCallback
+          );
+
           const response = await deploy({
             projectId: project,
             serviceName: service,
             region: region,
-            files: [folderPath],
+            zipBuffer,
+            hasDockerfile,
             skipIamCheck: skipIamCheck, // Pass the new flag
             progressCallback,
           });
@@ -565,11 +580,18 @@ export const registerTools = (
           await progressCallback({
             data: `Starting deployment of file contents for service ${service} in project ${project}...`,
           });
+
+          const { zipBuffer, hasDockerfile } = await zipFiles(
+            files,
+            progressCallback
+          );
+
           const response = await deploy({
             projectId: project,
             serviceName: service,
             region: region,
-            files: files,
+            zipBuffer,
+            hasDockerfile,
             skipIamCheck: skipIamCheck, // Pass the new flag
             progressCallback,
           });
@@ -897,12 +919,8 @@ export const registerToolsRemote = async (
           `New deploy request (remote): ${JSON.stringify({ project: currentProject, region, service, files })}`
         );
 
-        if (
-          typeof files !== 'object' ||
-          !Array.isArray(files) ||
-          files.length === 0
-        ) {
-          throw new Error('Files must be specified');
+        if (!files || !Array.isArray(files) || files.length === 0) {
+          throw new Error('Error: files array is required and must not be empty.');
         }
 
         // Validate that each file has content
@@ -919,11 +937,18 @@ export const registerToolsRemote = async (
           await progressCallback({
             data: `Starting deployment of file contents for service ${service} in project ${currentProject}...`,
           });
+
+          const { zipBuffer, hasDockerfile } = await zipFiles(
+            files,
+            progressCallback
+          );
+
           const response = await deploy({
             projectId: currentProject,
             serviceName: service,
             region: region,
-            files: files,
+            zipBuffer,
+            hasDockerfile,
             skipIamCheck: skipIamCheck, // Pass the new flag
             progressCallback,
           });


### PR DESCRIPTION
This PR refactors the file archiving and deployment logic to improve modularity and testability, and fixes issue #85.

- The `deploy_local_files` tool now preserves directory structure while subtracting the common base.
- The archiving logic has been extracted into a new `lib/archive.js` module with its own tests.
- The `zipFiles` function now returns both the zip buffer and a boolean indicating if a Dockerfile is present.
- The `deploy` function in `lib/cloud-run-deploy.js` now accepts the zip buffer and Dockerfile presence as arguments, instead of the list of files.
- The `tools.js` file has been updated to use the new `zipFiles` function and pass the correct arguments to the `deploy` function.