### PR TITLE
feat: Require service name for deployment

### DIFF
--- a/lib/cloud-run-deploy.js
+++ b/lib/cloud-run-deploy.js
@@ -720,6 +720,13 @@ export async function deploy({
     process.exit(1);
   }
 
+  if (!serviceName) {
+    const errorMsg =
+      'Error: serviceName is required in the configuration object.';
+    await logAndProgress(errorMsg, progressCallback, 'error');
+    process.exit(1);
+  }
+
   if (!files || !Array.isArray(files) || files.length === 0) {
     const errorMsg =
       'Error: files array is required in the configuration object.';
@@ -872,6 +879,13 @@ export async function deployImage({
   if (!projectId) {
     const errorMsg =
       'Error: projectId is required in the configuration object.';
+    await logAndProgress(errorMsg, progressCallback, 'error');
+    process.exit(1);
+  }
+
+  if (!serviceName) {
+    const errorMsg =
+      'Error: serviceName is required in the configuration object.';
     await logAndProgress(errorMsg, progressCallback, 'error');
     process.exit(1);
   }

--- a/test/need-gcp/cloud-run-deploy.test.js
+++ b/test/need-gcp/cloud-run-deploy.test.js
@@ -102,4 +102,32 @@ describe('Cloud Run Deployments', () => {
     };
     await deploy(configGoWithContent);
   });
+
+  test('should fail to deploy without a service name', async (t) => {
+    const config = {
+      projectId: projectId,
+      region: 'europe-west1',
+      files: ['example-sources-to-deploy/main.go'],
+    };
+    const error = new Error('process.exit() was called.');
+    const mockExit = t.mock.method(process, 'exit', () => {
+      throw error;
+    });
+    await assert.rejects(deploy(config), error);
+    assert.strictEqual(mockExit.mock.callCount(), 1);
+  });
+
+  test('should fail to deploy image without a service name', async (t) => {
+    const config = {
+      projectId: projectId,
+      region: 'europe-west1',
+      imageUrl: 'gcr.io/cloudrun/hello',
+    };
+    const error = new Error('process.exit() was called.');
+    const mockExit = t.mock.method(process, 'exit', () => {
+      throw error;
+    });
+    await assert.rejects(deployImage(config), error);
+    assert.strictEqual(mockExit.mock.callCount(), 1);
+  });
 });


### PR DESCRIPTION
Closes #108

This PR makes the 'serviceName' parameter mandatory in the `deploy` and `deployImage` functions. It's optional for the deploy tools, but if the default doesn't work, it could be passed as undefined. 

Changes:

- In `lib/cloud-run-deploy.js`:
    - The 'deploy' and 'deployImage' functions now check for the presence of 'serviceName' and exit if it's missing.
- In `test/need-gcp/cloud-run-deploy.test.js`:
    - Added tests to verify that the deployment fails when 'serviceName' is not provided.
   
I ran `npm run test:deploy`