### PR TITLE
fix: Report billing attachment errors

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -127,7 +127,7 @@ export const registerTools = (
           content: [
             {
               type: 'text',
-              text: `Successfully created GCP project with ID "${result.projectId}". You can now use this project ID for deployments.`,
+              text: result.billingMessage,
             },
           ],
         };


### PR DESCRIPTION
The create_project tool previously returned a generic success message even if attaching the billing account failed.

This change modifies the tool to return the detailed billing message from the underlying function, ensuring the user is correctly informed of the full status of the project creation.

Here's what the interaction with the agent looks like: 

```
╭──────────────────────────────────────────────────────╮
│  > create a new project called saraford-deleteme-52  │
╰──────────────────────────────────────────────────────╯

 ╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ ✔  create_project (cloud-run MCP Server) create_project (cloud-run MCP Server)                                                                                                     │
 │                                                                                                                                                                                    │
 │    Project saraford-deleteme-52 created. No billing accounts found. Please link billing manually: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}      │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

✦ I've created the project saraford-deleteme-52 for you. Please note that no billing accounts were found, so you'll need to link one manually using the provided URL.
```