### PR TITLE
feat: support using mcp server on sse mode using GCP_STDIO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ To use remote MCP Server in a MCP client:
 Start the MCP server locally with:
 
 ```bash
-npm run start
+GCP_STDIO=false node /path/to/this/repo/cloud-run-mcp/mcp-server.js
 ```
 
 Then, in your MCP client configuration, use the following:
@@ -85,6 +85,18 @@ Then, in your MCP client configuration, use the following:
     "cloud-run": {
       "command": "npx",
       "args": ["mcp-remote", "http://localhost:3000/sse"]
+    }
+  }
+}
+```
+
+or, if your client supports the `url` attribute, you can use:
+
+```
+{
+  "mcpServers": {
+    "cloud-run": {
+      "url": "http://localhost:3000/sse"
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Then, in your MCP client configuration, use the following:
   "mcpServers": {
     "cloud-run": {
       "command": "npx",
-      "args": ["mcp-remote", "http://localhost:3000/sse"]
+      "args": ["mcp-remote", "http://localhost:3000/mcp"]
     }
   }
 }
@@ -96,7 +96,7 @@ or, if your client supports the `url` attribute, you can use:
 {
   "mcpServers": {
     "cloud-run": {
-      "url": "http://localhost:3000/sse"
+      "url": "http://localhost:3000/mcp"
     }
   }
 }

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -43,10 +43,7 @@ function makeLoggingCompatibleWithStdio() {
 }
 
 function shouldStartStdio() {
-  if (process.env.GCP_STDIO) {
-    return true;
-  }
-  if (gcpInfo && gcpInfo.project) {
+  if (process.env.GCP_STDIO === 'false' || (gcpInfo && gcpInfo.project)) {
     return false;
   }
   return true;

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -122,7 +122,8 @@ if (shouldStartStdio()) {
   await server.connect(stdioTransport);
   console.log('Cloud Run MCP server stdio transport connected');
 } else {
-  console.log('Running on GCP, stdio transport will not be started.');
+  // non-stdio mode
+  console.log('Stdio transport mode is turned off.');
   gcpCredentialsAvailable = await ensureGCPCredentials();
   const app = express();
   app.use(express.json());

--- a/test/local/mcp-server-streamable-http.test.js
+++ b/test/local/mcp-server-streamable-http.test.js
@@ -1,0 +1,86 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'child_process';
+
+class MCPClient {
+    client = null;
+    transport = null;
+
+    constructor(serverName) {
+        this.client = new Client({ name: `mcp-client-for-${serverName}`, version: "1.0.0", url: `http://localhost:3000/mcp` });
+    }
+
+    async connectToServer(serverUrl) {
+        this.transport = new StreamableHTTPClientTransport(serverUrl);
+        await this.client.connect(this.transport);
+    }
+
+    async listTools() {
+        return await this.client.listTools();
+    }
+
+    async listPrompts() {
+        return await this.client.listPrompts();
+    }
+
+    async cleanup() {
+        await this.client.close();
+    }
+}
+
+describe('MCP Server in HTTP mode', () => {
+    let client;
+    let serverProcess;
+
+    before(async () => {
+        // Start MCP server as a child process
+        serverProcess = spawn('node', ['mcp-server.js'], {
+            cwd: process.cwd(),
+            env: { ...process.env, GCP_STDIO: 'false' },
+            stdio: 'inherit'
+        });
+
+        // Wait for server to start (better: poll the port, here we just wait)
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        client = new MCPClient("http-server");
+        await client.connectToServer("http://localhost:3000/mcp");
+    });
+
+    after(async () => {
+        await client.cleanup();
+        if (serverProcess) {
+            serverProcess.kill();
+        }
+    });
+
+    test('should list tools', async () => {
+        const response = await client.listTools();
+        const tools = response.tools;
+        assert(Array.isArray(tools));
+        const toolNames = tools.map((t) => t.name);
+        assert.deepStrictEqual(
+            toolNames.sort(),
+            [
+                'create_project',
+                'deploy_container_image',
+                'deploy_file_contents',
+                'deploy_local_folder',
+                'get_service',
+                'get_service_log',
+                'list_projects',
+                'list_services',
+            ].sort()
+        );
+    });
+
+    test('should list prompts', async () => {
+        const response = await client.listPrompts();
+        const prompts = response.prompts;
+        assert(Array.isArray(prompts));
+        const promptNames = prompts.map((p) => p.name);
+        assert.deepStrictEqual(promptNames.sort(), ['deploy', 'logs'].sort());
+    });
+});

--- a/test/local/mcp-server-streamable-http.test.js
+++ b/test/local/mcp-server-streamable-http.test.js
@@ -17,14 +17,6 @@ class MCPClient {
         await this.client.connect(this.transport);
     }
 
-    async listTools() {
-        return await this.client.listTools();
-    }
-
-    async listPrompts() {
-        return await this.client.listPrompts();
-    }
-
     async cleanup() {
         await this.client.close();
     }
@@ -46,7 +38,6 @@ describe('MCP Server in Streamble HTTP mode', () => {
         await new Promise(resolve => setTimeout(resolve, 2000));
 
         client = new MCPClient("http-server");
-        await client.connectToServer("http://localhost:3000/mcp");
     });
 
     after(async () => {
@@ -56,31 +47,7 @@ describe('MCP Server in Streamble HTTP mode', () => {
         }
     });
 
-    test('should list tools over streamble-http', async () => {
-        const response = await client.listTools();
-        const tools = response.tools;
-        assert(Array.isArray(tools));
-        const toolNames = tools.map((t) => t.name);
-        assert.deepStrictEqual(
-            toolNames.sort(),
-            [
-                'create_project',
-                'deploy_container_image',
-                'deploy_file_contents',
-                'deploy_local_folder',
-                'get_service',
-                'get_service_log',
-                'list_projects',
-                'list_services',
-            ].sort()
-        );
-    });
-
-    test('should list prompts over streamble-http', async () => {
-        const response = await client.listPrompts();
-        const prompts = response.prompts;
-        assert(Array.isArray(prompts));
-        const promptNames = prompts.map((p) => p.name);
-        assert.deepStrictEqual(promptNames.sort(), ['deploy', 'logs'].sort());
+    test('should start an HTTP server', async () => {
+        await client.connectToServer("http://localhost:3000/mcp");
     });
 });

--- a/test/local/mcp-server-streamable-http.test.js
+++ b/test/local/mcp-server-streamable-http.test.js
@@ -30,7 +30,7 @@ class MCPClient {
     }
 }
 
-describe('MCP Server in HTTP mode', () => {
+describe('MCP Server in Streamble HTTP mode', () => {
     let client;
     let serverProcess;
 
@@ -56,7 +56,7 @@ describe('MCP Server in HTTP mode', () => {
         }
     });
 
-    test('should list tools', async () => {
+    test('should list tools over streamble-http', async () => {
         const response = await client.listTools();
         const tools = response.tools;
         assert(Array.isArray(tools));
@@ -76,7 +76,7 @@ describe('MCP Server in HTTP mode', () => {
         );
     });
 
-    test('should list prompts', async () => {
+    test('should list prompts over streamble-http', async () => {
         const response = await client.listPrompts();
         const prompts = response.prompts;
         assert(Array.isArray(prompts));


### PR DESCRIPTION
This is based on the observations here: https://github.com/GoogleCloudPlatform/cloud-run-mcp/issues/113
Closes https://github.com/GoogleCloudPlatform/cloud-run-mcp/issues/113

Ideally, setting GCP_STDIO as false should start the server in SSE mode, which was not the case.
This PR ensures this behavior.
