### PR TITLE
feat: Implement additional checks for billing account before enabling any Apis

### DIFF
--- a/lib/cloud-api/billing.js
+++ b/lib/cloud-api/billing.js
@@ -96,3 +96,28 @@ export async function attachProjectToBillingAccount(
     return null;
   }
 }
+
+/**
+ * Checks if billing is enabled for a given project.
+ * @async
+ * @function isBillingEnabled
+ * @param {string} projectId - The ID of the project to check.
+ * @returns {Promise<boolean>} A promise that resolves to true if billing is enabled, false otherwise.
+ */
+export async function isBillingEnabled(projectId) {
+  const { CloudBillingClient } = await import('@google-cloud/billing');
+  const client = new CloudBillingClient();
+  const projectName = `projects/${projectId}`;
+  try {
+    const [billingInfo] = await client.getProjectBillingInfo({
+      name: projectName,
+    });
+    return billingInfo.billingEnabled || false;
+  } catch (error) {
+    console.error(
+      `Error checking billing status for project ${projectId}:`,
+      error.message || error
+    );
+    return false;
+  }
+}

--- a/lib/cloud-api/helpers.js
+++ b/lib/cloud-api/helpers.js
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {
+  isBillingEnabled,
+  listBillingAccounts,
+  attachProjectToBillingAccount,
+} from './billing.js';
+
 /**
  * Calls a function with retry logic for GCP API calls.
  * Retries on gRPC error code 7 (PERMISSION_DENIED).
@@ -104,6 +110,50 @@ export async function ensureApisEnabled(
   apis,
   progressCallback
 ) {
+  if (!(await isBillingEnabled(projectId))) {
+    // Billing is disabled, try to fix it.
+    const accounts = await listBillingAccounts();
+
+    if (accounts && accounts.length === 1 && accounts[0].open) {
+      // Exactly one open account found, try to attach it.
+      const account = accounts[0];
+      const attemptMessage = `Billing is not enabled for project ${projectId}. Found one open billing account: ${account.displayName} (${account.name}). Attempting to attach it...`;
+      console.log(attemptMessage);
+      if (progressCallback)
+        progressCallback({ level: 'info', data: attemptMessage });
+
+      const attachmentResult = await attachProjectToBillingAccount(
+        projectId,
+        account.name
+      );
+
+      if (!attachmentResult || !attachmentResult.billingEnabled) {
+        const attachFailMessage = `Failed to automatically attach project ${projectId} to billing account ${account.name}. Please enable billing manually: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`;
+        if (progressCallback)
+          progressCallback({ level: 'error', data: attachFailMessage });
+        throw new Error(attachFailMessage);
+      }
+      const attachSuccessMessage = `Successfully attached project ${projectId} to billing account ${account.name}.`;
+      console.log(attachSuccessMessage);
+      if (progressCallback)
+        progressCallback({ level: 'info', data: attachSuccessMessage });
+      // If we get here, billing is now enabled, and we can proceed to API checks.
+    } else {
+      // Cannot auto-attach. Throw error.
+      let reason;
+      if (!accounts || accounts.length === 0) {
+        reason = 'no billing accounts were found';
+      } else if (accounts.length > 1) {
+        reason = 'multiple billing accounts were found';
+      } else {
+        reason = `the only available billing account '${accounts[0].displayName}' is not open`;
+      }
+      const errorMessage = `Billing is not enabled for project ${projectId}, and it could not be enabled automatically because ${reason}. Please enable billing to use Google Cloud services: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`;
+      if (progressCallback)
+        progressCallback({ level: 'error', data: errorMessage });
+      throw new Error(errorMessage);
+    }
+  }
   const message = 'Checking and enabling required APIs...';
   console.log(message);
   if (progressCallback) progressCallback({ level: 'info', data: message });

--- a/test/local/helpers.test.js
+++ b/test/local/helpers.test.js
@@ -1,0 +1,287 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'node:assert/strict';
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import esmock from 'esmock';
+
+describe('ensureApisEnabled', () => {
+  let billingMocks;
+  let ensureApisEnabled;
+  let mockServiceUsageClient;
+  let mockProgressCallback;
+  const projectId = 'test-project';
+  const apis = ['test-api.googleapis.com'];
+
+  beforeEach(async () => {
+    billingMocks = {
+      isBillingEnabled: mock.fn(),
+      listBillingAccounts: mock.fn(),
+      attachProjectToBillingAccount: mock.fn(),
+    };
+    const helpers = await esmock('../../lib/cloud-api/helpers.js', {
+      '../../lib/cloud-api/billing.js': billingMocks,
+    });
+    ensureApisEnabled = helpers.ensureApisEnabled;
+    mockServiceUsageClient = {
+      getService: mock.fn(),
+      enableService: mock.fn(() => [{ promise: () => Promise.resolve() }]),
+    };
+    mockProgressCallback = mock.fn();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  describe('Billing Enabled', () => {
+    it('should do nothing if API is already enabled', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(true)
+      );
+      mockServiceUsageClient.getService.mock.mockImplementation(() =>
+        Promise.resolve([{ state: 'ENABLED' }])
+      );
+
+      await ensureApisEnabled(
+        { serviceUsageClient: mockServiceUsageClient },
+        projectId,
+        apis,
+        mockProgressCallback
+      );
+
+      assert.strictEqual(mockServiceUsageClient.getService.mock.callCount(), 1);
+      assert.strictEqual(
+        mockServiceUsageClient.enableService.mock.callCount(),
+        0
+      );
+    });
+
+    it('should enable API if it is disabled', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(true)
+      );
+      mockServiceUsageClient.getService.mock.mockImplementation(() =>
+        Promise.resolve([{ state: 'DISABLED' }])
+      );
+
+      await ensureApisEnabled(
+        { serviceUsageClient: mockServiceUsageClient },
+        projectId,
+        apis,
+        mockProgressCallback
+      );
+
+      assert.strictEqual(mockServiceUsageClient.getService.mock.callCount(), 1);
+      assert.strictEqual(
+        mockServiceUsageClient.enableService.mock.callCount(),
+        1
+      );
+    });
+
+    it('should retry enabling API if checkAndEnableApi fails once', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(true)
+      );
+      let getServiceCallCount = 0;
+      mockServiceUsageClient.getService.mock.mockImplementation(() => {
+        getServiceCallCount++;
+        if (getServiceCallCount === 1) {
+          return Promise.reject(new Error('First fail'));
+        }
+        return Promise.resolve([{ state: 'ENABLED' }]);
+      });
+
+      await ensureApisEnabled(
+        { serviceUsageClient: mockServiceUsageClient },
+        projectId,
+        apis,
+        mockProgressCallback
+      );
+
+      assert.strictEqual(mockServiceUsageClient.getService.mock.callCount(), 2);
+      assert.strictEqual(
+        mockServiceUsageClient.enableService.mock.callCount(),
+        0
+      );
+    });
+
+    it('should throw if checkAndEnableApi fails after retry', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(true)
+      );
+      mockServiceUsageClient.getService.mock.mockImplementation(() =>
+        Promise.reject(new Error('Always fail'))
+      );
+
+      await assert.rejects(
+        () =>
+          ensureApisEnabled(
+            { serviceUsageClient: mockServiceUsageClient },
+            projectId,
+            apis,
+            mockProgressCallback
+          ),
+        {
+          message:
+            'Failed to ensure API [test-api.googleapis.com] is enabled after retry. Please check manually.',
+        }
+      );
+      assert.strictEqual(mockServiceUsageClient.getService.mock.callCount(), 2);
+    });
+  });
+
+  describe('Billing Disabled', () => {
+    it('should throw if no billing accounts are found', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(false)
+      );
+      billingMocks.listBillingAccounts.mock.mockImplementation(() =>
+        Promise.resolve([])
+      );
+
+      await assert.rejects(
+        () =>
+          ensureApisEnabled(
+            { serviceUsageClient: mockServiceUsageClient },
+            projectId,
+            apis,
+            mockProgressCallback
+          ),
+        {
+          message: `Billing is not enabled for project ${projectId}, and it could not be enabled automatically because no billing accounts were found. Please enable billing to use Google Cloud services: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`,
+        }
+      );
+    });
+
+    it('should throw if multiple billing accounts are found', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(false)
+      );
+      billingMocks.listBillingAccounts.mock.mockImplementation(() =>
+        Promise.resolve([{}, {}])
+      );
+
+      await assert.rejects(
+        () =>
+          ensureApisEnabled(
+            { serviceUsageClient: mockServiceUsageClient },
+            projectId,
+            apis,
+            mockProgressCallback
+          ),
+        {
+          message: `Billing is not enabled for project ${projectId}, and it could not be enabled automatically because multiple billing accounts were found. Please enable billing to use Google Cloud services: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`,
+        }
+      );
+    });
+
+    it('should throw if the only billing account is not open', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(false)
+      );
+      billingMocks.listBillingAccounts.mock.mockImplementation(() =>
+        Promise.resolve([{ displayName: 'Closed Account', open: false }])
+      );
+
+      await assert.rejects(
+        () =>
+          ensureApisEnabled(
+            { serviceUsageClient: mockServiceUsageClient },
+            projectId,
+            apis,
+            mockProgressCallback
+          ),
+        {
+          message: `Billing is not enabled for project ${projectId}, and it could not be enabled automatically because the only available billing account 'Closed Account' is not open. Please enable billing to use Google Cloud services: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`,
+        }
+      );
+    });
+
+    it('should attach billing and enable API if one open account is found', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(false)
+      );
+      billingMocks.listBillingAccounts.mock.mockImplementation(() =>
+        Promise.resolve([
+          {
+            name: 'billingAccounts/123',
+            displayName: 'Open Account',
+            open: true,
+          },
+        ])
+      );
+      billingMocks.attachProjectToBillingAccount.mock.mockImplementation(() =>
+        Promise.resolve({ billingEnabled: true })
+      );
+      mockServiceUsageClient.getService.mock.mockImplementation(() =>
+        Promise.resolve([{ state: 'ENABLED' }])
+      );
+
+      await ensureApisEnabled(
+        { serviceUsageClient: mockServiceUsageClient },
+        projectId,
+        apis,
+        mockProgressCallback
+      );
+
+      assert.strictEqual(
+        billingMocks.attachProjectToBillingAccount.mock.callCount(),
+        1
+      );
+      assert.strictEqual(mockServiceUsageClient.getService.mock.callCount(), 1);
+      assert.strictEqual(
+        mockServiceUsageClient.enableService.mock.callCount(),
+        0
+      );
+    });
+
+    it('should throw if attaching the billing account fails', async () => {
+      billingMocks.isBillingEnabled.mock.mockImplementation(() =>
+        Promise.resolve(false)
+      );
+      billingMocks.listBillingAccounts.mock.mockImplementation(() =>
+        Promise.resolve([
+          {
+            name: 'billingAccounts/123',
+            displayName: 'Open Account',
+            open: true,
+          },
+        ])
+      );
+      billingMocks.attachProjectToBillingAccount.mock.mockImplementation(() =>
+        Promise.resolve({ billingEnabled: false })
+      );
+
+      await assert.rejects(
+        () =>
+          ensureApisEnabled(
+            { serviceUsageClient: mockServiceUsageClient },
+            projectId,
+            apis,
+            mockProgressCallback
+          ),
+        {
+          message: `Failed to automatically attach project ${projectId} to billing account billingAccounts/123. Please enable billing manually: https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`,
+        }
+      );
+      assert.strictEqual(
+        billingMocks.attachProjectToBillingAccount.mock.callCount(),
+        1
+      );
+    });
+  });
+});


### PR DESCRIPTION
Addresses #3
Implemented a pre-check within the deployment workflow to verify that a project has a billing account enabled before attempting to call the `ensureApisEnabled` function. This prevents deployment failures that occur when API enablement is attempted on projects without billing.

Details:
-   The system now checks for an active billing account before proceeding with API enablement.
-   If no billing account is associated with the project, the deployment will now fail early with a specific error message indicating that billing is required.