### PR TITLE
feat: Setup end to end integration tests

### DIFF
--- a/.kokoro/presubmit.cfg
+++ b/.kokoro/presubmit.cfg
@@ -14,3 +14,8 @@ env_vars {
   key: "GOOGLE_CLOUD_PROJECT"
   value: "cloud-run-mcp-server-testing"
 }
+
+env_vars {
+  key: "GCP_PARENT"
+  value: "folders/583132987080"
+}

--- a/.kokoro/run_tests.sh
+++ b/.kokoro/run_tests.sh
@@ -24,6 +24,8 @@ cd "$(dirname "$0")"/..
 npm install
 
 # Run tests
+npm run test:workflows # Run tests related to all workflows
+npm run test:projects # Run tests related to GCP projects
 npm run test:services # Run tests related to services
 npm run test:deploy # Run tests related to deployments
 npm run test:gcp-auth # Run tests related to GCP authentication

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,20 @@
+# Reviewing Pull Requests
+
+This document provides guidelines for reviewing Pull Requests.
+
+## Guidelines
+
+### Presubmit Tests
+
+Running presubmit tests is a mandatory requirement for Pull Requests to be eligible for submission.
+
+**Before triggering tests:**
+Review the code changes, especially new or modified tests, to ensure they do not contain any malicious or harmful code that could unnecessarily consume or harm Google's resources during test execution. In particular, ensure the tests:
+
+- **Do not modify environment variables:** The tests should not modify environment variables in an unexpected or harmful way.
+- **Do not consume excessive resources:** Ensure tests do not create an excessive number of Google Cloud projects or other high-cost resources.
+- **Do not contain hardcoded credentials:** Credentials should not be present in the code.
+- **Do not rely on untrusted external dependencies:** Any new external dependencies should be reviewed for trustworthiness.
+
+**Triggering tests:**
+If the code is safe to run, trigger presubmit tests by adding a comment with `kokoro:run` to the Pull Request. Tests are run via Kokoro.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "deploy": "gcloud run deploy cloud-run-mcp --source . --no-invoker-iam-check",
+    "test:workflows": "node --test test/need-gcp/workflows/*.test.js",
     "test:deploy": "node test/need-gcp/deployer.test.js",
     "test:projects": "node test/need-gcp/gcp-projects.test.js",
     "test:services": "node test/need-gcp/cloud-run-services.test.js",

--- a/test/need-gcp/deployer.test.js
+++ b/test/need-gcp/deployer.test.js
@@ -17,8 +17,6 @@ limitations under the License.
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { deploy, deployImage } from '../../lib/deployment/deployer.js';
-import fs from 'fs/promises';
-import path from 'path';
 
 const projectId = process.env.GOOGLE_CLOUD_PROJECT || process.argv[2];
 if (!projectId) {
@@ -27,53 +25,6 @@ if (!projectId) {
 }
 
 describe('Cloud Run Deployments', () => {
-  test('should deploy a container image', async () => {
-    const configImageDeploy = {
-      projectId: projectId,
-      serviceName: 'hello-from-image',
-      region: 'europe-west1',
-      imageUrl: 'gcr.io/cloudrun/hello',
-    };
-    await deployImage(configImageDeploy);
-  });
-
-  test('should fail to deploy with invalid files', async () => {
-    const configFailingBuild = {
-      projectId: projectId,
-      serviceName: 'example-failing-app',
-      region: 'europe-west1',
-      files: [
-        {
-          filename: 'main.txt',
-          content:
-            'This is not a valid application source file and should cause a build failure.',
-        },
-      ],
-    };
-    await assert.rejects(deploy(configFailingBuild));
-  });
-
-  test('should deploy a Go app with file content (Buildpacks)', async () => {
-    const mainGoContent = await fs.readFile(
-      path.resolve('example-sources-to-deploy/main.go'),
-      'utf-8'
-    );
-    const goModContent = await fs.readFile(
-      path.resolve('example-sources-to-deploy/go.mod'),
-      'utf-8'
-    );
-    const configGoWithContent = {
-      projectId: projectId,
-      serviceName: 'example-go-app-content',
-      region: 'europe-west1',
-      files: [
-        { filename: 'main.go', content: mainGoContent },
-        { filename: 'go.mod', content: goModContent },
-      ],
-    };
-    await deploy(configGoWithContent);
-  });
-
   test('should fail to deploy without a service name', async () => {
     const config = {
       projectId: projectId,

--- a/test/need-gcp/gcp-projects.test.js
+++ b/test/need-gcp/gcp-projects.test.js
@@ -15,60 +15,9 @@ limitations under the License.
 */
 
 import { test } from 'node:test';
-import assert from 'node:assert';
-import {
-  createProjectAndAttachBilling,
-  deleteProject,
-  generateProjectId,
-} from '../../lib/cloud-api/projects.js';
+import { setupProject } from './test-helpers.js';
 
-test('should create a new project and attach billing', async () => {
+test('should create a new project and attach billing', async (t) => {
   console.log('Attempting to create a new project and attach billing...');
-  let newProjectResult = null;
-
-  const projectId = 'test-' + generateProjectId(); // e.g., test-mcp-cvc-cvc format
-  console.log(`Generated project ID: ${projectId}`);
-
-  // Parent is required because service accounts cannot create projects without a parent.
-  const parent = process.env.GCP_PARENT || process.argv[2];
-  console.log(`Using parent: ${parent}`);
-
-  try {
-    newProjectResult = await createProjectAndAttachBilling(projectId, parent);
-    assert(newProjectResult, 'newProjectResult should not be null');
-    assert(
-      newProjectResult.projectId,
-      'newProjectResult.projectId should not be null'
-    );
-    assert(
-      newProjectResult.billingMessage,
-      'newProjectResult.billingMessage should not be null'
-    );
-    assert(
-      newProjectResult.billingMessage.startsWith(
-        `Project ${newProjectResult.projectId} created successfully.`
-      ),
-      'newProjectResult.billingMessage should start with success message'
-    );
-
-    console.log(`Successfully created project: ${newProjectResult.projectId}`);
-    console.log(newProjectResult.billingMessage);
-  } finally {
-    if (newProjectResult && newProjectResult.projectId) {
-      console.log(
-        `Attempting to delete project: ${newProjectResult.projectId}`
-      );
-      try {
-        await deleteProject(newProjectResult.projectId);
-        console.log(
-          `Successfully deleted project: ${newProjectResult.projectId}`
-        );
-      } catch (error) {
-        console.error(
-          `Error deleting project ${newProjectResult.projectId}:`,
-          error
-        );
-      }
-    }
-  }
+  await setupProject(t);
 });

--- a/test/need-gcp/test-helpers.js
+++ b/test/need-gcp/test-helpers.js
@@ -1,0 +1,168 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import assert from 'node:assert';
+import {
+  createProjectAndAttachBilling,
+  deleteProject,
+  generateProjectId,
+} from '../../lib/cloud-api/projects.js';
+import {
+  callWithRetry,
+  ensureApisEnabled,
+} from '../../lib/cloud-api/helpers.js';
+
+/**
+ * Gets project number from project ID.
+ * @param {string} projectId
+ * @returns {Promise<string>} project number
+ */
+export async function getProjectNumber(projectId) {
+  const { ProjectsClient } = await import('@google-cloud/resource-manager');
+  const client = new ProjectsClient();
+  try {
+    const [project] = await client.getProject({
+      name: `projects/${projectId}`,
+    });
+    // project.name is in format projects/123456
+    return project.name.split('/')[1];
+  } catch (error) {
+    console.error(
+      `Error getting project number for project ${projectId}:`,
+      error.message
+    );
+    throw error;
+  }
+}
+
+/**
+ * Adds an IAM policy binding to a project.
+ * @param {string} projectId The project ID.
+ * @param {string} member The member to add, e.g., 'user:foo@example.com'.
+ * @param {string} role The role to grant, e.g., 'roles/viewer'.
+ */
+export async function addIamPolicyBinding(projectId, member, role) {
+  const { ProjectsClient } = await import('@google-cloud/resource-manager');
+  const client = new ProjectsClient();
+
+  console.log(
+    `Adding IAM binding for ${member} with role ${role} to project ${projectId}`
+  );
+
+  try {
+    const [policy] = await client.getIamPolicy({
+      resource: `projects/${projectId}`,
+    });
+
+    console.log('Current IAM Policy:', JSON.stringify(policy, null, 2));
+
+    // Check if the binding already exists
+    const binding = policy.bindings.find((b) => b.role === role);
+    if (binding) {
+      if (!binding.members.includes(member)) {
+        binding.members.push(member);
+      }
+    } else {
+      policy.bindings.push({
+        role: role,
+        members: [member],
+      });
+    }
+
+    console.log('Updated IAM Policy:', JSON.stringify(policy, null, 2));
+
+    // Set the updated policy
+    await client.setIamPolicy({
+      resource: `projects/${projectId}`,
+      policy: policy,
+    });
+
+    console.log(
+      `Successfully added IAM binding for ${member} with role ${
+        role
+      } to project ${projectId}`
+    );
+  } catch (error) {
+    console.error(
+      `Error adding IAM policy binding to project ${projectId}:`,
+      error.message
+    );
+    throw error;
+  }
+}
+
+/**
+ * Create project, attach billing and register cleanup.
+ * @param {object} testContext
+ * @returns {Promise<string>} projectId
+ */
+export async function setupProject(testContext) {
+  const projectId = 'test-' + generateProjectId();
+  console.log(`Generated project ID: ${projectId}`);
+  const parent = process.env.GCP_PARENT || process.argv[2];
+  const newProjectResult = await createProjectAndAttachBilling(
+    projectId,
+    parent
+  );
+  assert(newProjectResult, 'newProjectResult should not be null');
+  assert(
+    newProjectResult.projectId,
+    'newProjectResult.projectId should not be null'
+  );
+  assert(
+    newProjectResult.billingMessage,
+    'newProjectResult.billingMessage should not be null'
+  );
+  assert(
+    newProjectResult.billingMessage.startsWith(
+      `Project ${newProjectResult.projectId} created successfully.`
+    ),
+    'newProjectResult.billingMessage should start with success message'
+  );
+  console.log(`Successfully created project: ${newProjectResult.projectId}`);
+  console.log(newProjectResult.billingMessage);
+
+  testContext.after(async () => {
+    try {
+      await deleteProject(projectId);
+      console.log(`Successfully deleted project: ${projectId}`);
+    } catch (e) {
+      console.error(`Failed to delete project ${projectId}:`, e.message);
+    }
+  });
+
+  return projectId;
+}
+
+/**
+ * Enable APIs and set IAM permissions for source deployments.
+ * @param {string} projectId
+ */
+export async function setSourceDeployProjectPermissions(projectId) {
+  const { ServiceUsageClient } = await import('@google-cloud/service-usage');
+  const serviceUsageClient = new ServiceUsageClient({ projectId });
+  const context = {
+    serviceUsageClient: serviceUsageClient,
+  };
+  await ensureApisEnabled(context, projectId, ['run.googleapis.com']);
+  console.log('Adding editor role to Compute SA...');
+  const projectNumber = await getProjectNumber(projectId);
+  const member = `serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`;
+  await callWithRetry(
+    () => addIamPolicyBinding(projectId, member, 'roles/editor'),
+    `addIamPolicyBinding roles/editor to ${member}`
+  );
+  console.log('Compute SA editor role added.');
+}

--- a/test/need-gcp/workflows/deployment-workflows.test.js
+++ b/test/need-gcp/workflows/deployment-workflows.test.js
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fs from 'fs/promises';
+import assert from 'node:assert';
+import { test } from 'node:test';
+import path from 'path';
+
+import { deploy, deployImage } from '../../../lib/deployment/deployer.js';
+import {
+  setSourceDeployProjectPermissions,
+  setupProject,
+} from '../test-helpers.js';
+
+test('Scenario-1: Starting deployment of hello image...', async (testContext) => {
+  const projectId = await setupProject(testContext);
+  const configImageDeploy = {
+    projectId: projectId,
+    serviceName: 'hello-scenario',
+    region: 'europe-west1',
+    imageUrl: 'gcr.io/cloudrun/hello',
+  };
+  await deployImage(configImageDeploy);
+
+  console.log('Scenario-1: Deployment completed.');
+});
+
+test('Scenario-2: Starting deployment with invalid files...', async (testContext) => {
+  const projectId = await setupProject(testContext);
+  await setSourceDeployProjectPermissions(projectId);
+  const configFailingBuild = {
+    projectId: projectId,
+    serviceName: 'example-failing-app',
+    region: 'europe-west1',
+    files: [
+      {
+        filename: 'main.txt',
+        content:
+          'This is not a valid application source file and should cause a build failure.',
+      },
+    ],
+  };
+  await assert.rejects(
+    deploy(configFailingBuild),
+    { message: /ERROR: failed to detect: no buildpacks participating/ },
+    'Deployment should have failed with a buildpack detection error'
+  );
+});
+
+test('Scenario-3: Starting deployment of Go app with file content...', async (testContext) => {
+  const projectId = await setupProject(testContext);
+  await setSourceDeployProjectPermissions(projectId);
+  const mainGoContent = await fs.readFile(
+    path.resolve('example-sources-to-deploy/main.go'),
+    'utf-8'
+  );
+  const goModContent = await fs.readFile(
+    path.resolve('example-sources-to-deploy/go.mod'),
+    'utf-8'
+  );
+  const configGoWithContent = {
+    projectId: projectId,
+    serviceName: 'example-go-app-content',
+    region: 'europe-west1',
+    files: [
+      { filename: 'main.go', content: mainGoContent },
+      { filename: 'go.mod', content: goModContent },
+    ],
+  };
+  await deploy(configGoWithContent);
+  console.log('Scenario-3: Deployment completed.');
+});


### PR DESCRIPTION
We currently run integration tests for individual scenarios as part of the GitHub PR presubmit process. These tests successfully validate core functionalities such as authentication, project creation and deletion, deployment scenarios, and service details. However, they lack coverage for critical end-to-end user workflows.

This PR introduces a new test suite designed to simulate a real user's journey as comprehensively as possible. The test cases cover all deployment scenarios on a newly created, dedicated GCP project for each test run. Each test will create a project, attach a billing account, perform the deployment, and then delete the project.