### PR TITLE
Fix: Add serviceusage.googleapis.com to required APIs (#166)

### DIFF
--- a/lib/deployment/deployer.js
+++ b/lib/deployment/deployer.js
@@ -37,10 +37,14 @@ const REQUIRED_APIS_FOR_SOURCE_DEPLOY = [
   'cloudbuild.googleapis.com',
   'artifactregistry.googleapis.com',
   'run.googleapis.com',
+  'serviceusage.googleapis.com',
 ];
 
 // APIs required for deploying a container image.
-const REQUIRED_APIS_FOR_IMAGE_DEPLOY = ['run.googleapis.com'];
+const REQUIRED_APIS_FOR_IMAGE_DEPLOY = [
+  'run.googleapis.com',
+  'serviceusage.googleapis.com',
+];
 
 /**
  * Deploys or updates a Cloud Run service with the specified container image.


### PR DESCRIPTION
Adds `serviceusage.googleapis.com` to both `REQUIRED_APIS_FOR_SOURCE_DEPLOY` and `REQUIRED_APIS_FOR_IMAGE_DEPLOY` in lib/deployment/deployer.js. This resolves deployment failures when the Service Usage API is disabled, as it's necessary for cloud-run-mcp to check and ensure other required APIs are enabled.

Fixes #166