### PR TITLE
fix: upgrade lodash to 4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "google-proto-files": "^5.0.0",
-        "lodash": "^4.17.23",
         "zod": "^3.25.76"
       },
       "bin": {


### PR DESCRIPTION
Resolving Prototype Pollution Vulnerability in Lodash: https://github.com/GoogleCloudPlatform/cloud-run-mcp/security/dependabot/12