### PR TITLE
feat: add optional filtering parameters to get_service_log tool

### DIFF
--- a/lib/cloud-api/run.js
+++ b/lib/cloud-api/run.js
@@ -114,29 +114,69 @@ export async function getService(projectId, location, serviceId) {
 }
 
 /**
+ * Builds a Cloud Logging filter string for Cloud Run logs.
+ * @param {string} serviceId - The Cloud Run service ID.
+ * @param {string} location - The Google Cloud location.
+ * @param {object} [filterOptions] - Optional filtering options.
+ * @param {string} [filterOptions.severity] - Minimum severity level (DEFAULT, INFO, WARNING, ERROR).
+ * @param {number} [filterOptions.freshnessMinutes] - Only fetch logs from the last N minutes.
+ * @param {string} [filterOptions.textFilter] - Text to search for in log entries.
+ * @returns {string} - The constructed filter string.
+ */
+function buildLogFilter(serviceId, location, filterOptions = {}) {
+  const severity = filterOptions.severity || 'DEFAULT';
+
+  let filter = `resource.type="cloud_run_revision"
+                resource.labels.service_name="${serviceId}"
+                resource.labels.location="${location}"
+                severity>=${severity}`;
+
+  // Add time-based filter if freshnessMinutes is specified
+  if (filterOptions.freshnessMinutes && filterOptions.freshnessMinutes > 0) {
+    const now = new Date();
+    const startTime = new Date(
+      now.getTime() - filterOptions.freshnessMinutes * 60 * 1000
+    );
+    filter += `\n                timestamp>="${startTime.toISOString()}"`;
+  }
+
+  // Add text filter if specified
+  if (filterOptions.textFilter && filterOptions.textFilter.trim() !== '') {
+    // Escape backslashes first, then quotes (order matters)
+    const escapedText = filterOptions.textFilter
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+    filter += `\n                textPayload=~"${escapedText}"`;
+  }
+
+  return filter;
+}
+
+/**
  * Fetches a paginated list of logs for a specific Cloud Run service.
  * @param {string} projectId - The Google Cloud project ID.
  * @param {string} location - The Google Cloud location (e.g., 'europe-west1').
  * @param {string} serviceId - The ID of the Cloud Run service.
- * @param {string} [requestOptions] - The token for the next page of results.
+ * @param {object} [requestOptions] - The token for the next page of results, or initial options.
+ * @param {object} [filterOptions] - Optional filtering options.
+ * @param {string} [filterOptions.severity] - Minimum severity level (DEFAULT, INFO, WARNING, ERROR).
+ * @param {number} [filterOptions.freshnessMinutes] - Only fetch logs from the last N minutes.
+ * @param {string} [filterOptions.textFilter] - Text to search for in log entries.
+ * @param {number} [filterOptions.pageSize] - Number of entries per page (default: 100, max: 1000).
  * @returns {Promise<{logs: string, requestOptions: object | undefined }>} - A promise that resolves to an object with log entries and a token for the next page.
  */
 export async function getServiceLogs(
   projectId,
   location,
   serviceId,
-  requestOptions
+  requestOptions,
+  filterOptions = {}
 ) {
   const loggingClient = await getLoggingClient(projectId);
 
   try {
-    const LOG_SEVERITY = 'DEFAULT'; // e.g., 'DEFAULT', 'INFO', 'WARNING', 'ERROR'
-    const PAGE_SIZE = 100; // Number of log entries to retrieve per page
-
-    const filter = `resource.type="cloud_run_revision"
-                    resource.labels.service_name="${serviceId}"
-                    resource.labels.location="${location}"
-                    severity>=${LOG_SEVERITY}`;
+    const pageSize = Math.min(filterOptions.pageSize || 100, 1000);
+    const filter = buildLogFilter(serviceId, location, filterOptions);
 
     console.log(
       `Fetching logs for Cloud Run service ${serviceId} in project ${projectId}, location ${location}...`
@@ -146,7 +186,7 @@ export async function getServiceLogs(
     const options = requestOptions || {
       filter: filter,
       orderBy: 'timestamp desc', // Get the latest logs first
-      pageSize: PAGE_SIZE,
+      pageSize: pageSize,
     };
     console.log(`Request options: ${JSON.stringify(options)}`);
 


### PR DESCRIPTION
## Summary

Add optional filtering parameters to `get_service_log` tool to help reduce API quota usage when fetching Cloud Run logs.

### New Parameters

| Parameter | Type | Description |
|-----------|------|-------------|
| `severity` | enum | Minimum log level (DEFAULT, DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY) |
| `freshnessMinutes` | number | Only fetch logs from the last N minutes |
| `textFilter` | string | Regex match on textPayload |
| `limit` | number | Entries per page (default: 100, max: 1000) |
| `maxPages` | number | Limit number of API requests/pages |

### Motivation

The current implementation fetches all logs without any filtering, which can quickly exhaust the Cloud Logging API quota ("Read requests per minute"). These optional parameters allow users to narrow down results and reduce API usage.

### Backward Compatibility

All new parameters are optional. Default behavior remains unchanged - without any filters, the tool fetches all available logs as before.

### Testing

- Unit tests pass
- Tested against real Cloud Logging API with various filter combinations