### PR TITLE
fix: vulnerability in hono package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.16.0.tgz",
-      "integrity": "sha512-7/5LRgykyOfQENcm6hDKP8SX/u9XxE5YOiWOkgkwcoO+cG8xT/cyOvp9wwN3IxfdYgpHs8CE7Nq2PKX2lNaEXw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.18.0.tgz",
+      "integrity": "sha512-r3ZwDMiz4nwW6R922Z1pwpePxyRwE5GdevYX63hRmAQUkUQJcBH/79EnQPDv5cOv1mFBgevdNWQfi3tie3dHrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -2260,9 +2260,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
Resolves multiple vulnerabilities in hono package:

- [Hono has an Arbitrary Key Read in Serve static Middleware (Cloudflare Workers Adapter)](https://github.com/GoogleCloudPlatform/cloud-run-mcp/security/dependabot/15)
- [Hono cache middleware ignores "Cache-Control: private" leading to Web Cache Deception](https://github.com/GoogleCloudPlatform/cloud-run-mcp/security/dependabot/14)
- [Hono IPv4 address validation bypass in IP Restriction Middleware allows IP spoofing](https://github.com/GoogleCloudPlatform/cloud-run-mcp/security/dependabot/13)
- [Hono vulnerable to XSS through ErrorBoundary component](https://github.com/GoogleCloudPlatform/cloud-run-mcp/security/dependabot/16)
