### PR TITLE
fix: prevent shell injection in deployment file operations

### DIFF
--- a/lib/deployment/source-processor.js
+++ b/lib/deployment/source-processor.js
@@ -19,11 +19,11 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import util from 'node:util';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { TEMP_PATHS, RUNTIMES } from './constants.js';
 import { logAndProgress } from '../util/helpers.js';
 
-const execAsync = util.promisify(exec);
+const execFileAsync = util.promisify(execFile);
 
 /**
  * Prepares a temporary directory with the source code for deployment.
@@ -48,7 +48,7 @@ export async function prepareSourceDirectory(files, progressCallback) {
     const stats = await fsp.stat(file);
     if (stats.isDirectory()) {
       // Copy directory contents
-      await execAsync(`cp -R "${file}/." "${tempDir}/"`);
+      await execFileAsync('cp', ['-R', `${file}/.`, `${tempDir}/`]);
     } else {
       const destPath = path.join(tempDir, path.basename(file));
       await fsp.copyFile(file, destPath);

--- a/lib/deployment/universal-maker.js
+++ b/lib/deployment/universal-maker.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -23,7 +23,7 @@ import { logAndProgress } from '../util/helpers.js';
 import { TEMP_PATHS } from './constants.js';
 import { ensureRepositoryDownloaded } from '../util/artifacts.js';
 
-const execAsync = util.promisify(exec);
+const execFileAsync = util.promisify(execFile);
 
 const UNIVERSAL_MAKER_BIN = 'universal_maker';
 const UM_VERSION = '1.0.0';
@@ -108,8 +108,11 @@ export async function runUniversalMaker(appDir, accessToken, progressCallback) {
       progressCallback,
       'debug'
     );
-    const command = `"${binPath}" -application_dir "${appDir}" -output_dir "${outputDir}" -output_format json`;
-    await execAsync(command);
+    await execFileAsync(binPath, [
+      '-application_dir', appDir,
+      '-output_dir', outputDir,
+      '-output_format', 'json',
+    ]);
 
     const outputPath = path.join(outputDir, 'build_output.json');
     if (fs.existsSync(outputPath)) {


### PR DESCRIPTION
## Summary

`source-processor.js` and `universal-maker.js` use `exec()` with string interpolation to run shell commands. User-controlled file paths are interpolated directly into the command string, allowing shell metacharacters to execute arbitrary commands.

## Fix

- `source-processor.js`: Replace `exec('cp -R ...')` with `execFile('cp', [args])` — no shell spawned
- `universal-maker.js`: Replace `exec(command_string)` with `execFile(binPath, [args])` — arguments passed as array

This is consistent with the safe pattern already used in `compose.js` (line 147).