### PR TITLE
feat: add server instructions and document MCP timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ Then configure the MCP server using either Node.js or Docker:
       }
    ```
 
+3. [Optional] Increase the MCP timeout
+
+   Cloud Run deployments trigger a Cloud Build, which can take several minutes to
+   complete. If your MCP client disconnects with a timeout error before the build
+   finishes, increase the client timeout. The build continues running on GCP even
+   after a client disconnect.
+
+   For **Gemini CLI**, set `timeout` (in milliseconds) in `~/.gemini/settings.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "cloud-run": {
+         "command": "npx",
+         "args": ["-y", "@google-cloud/cloud-run-mcp"],
+         "timeout": 300000
+       }
+     }
+   }
+   ```
+
+   Refer to your MCP client's documentation for the equivalent timeout setting.
+
 #### Using Docker
 
 See Docker's [MCP catalog](https://hub.docker.com/mcp/server/cloud-run-mcp/overview), or use these manual instructions:

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -83,7 +83,14 @@ async function getServer(accessToken = GCLOUD_AUTH) {
       name: 'cloud-run',
       version: '1.0.0',
     },
-    { capabilities: { logging: {} } }
+    {
+      capabilities: { logging: {} },
+      instructions:
+        'Use this server to deploy and manage applications on Google Cloud Run. ' +
+        'Available tools: deploy source code or file contents to Cloud Run, list services, ' +
+        'get service details, and retrieve service logs. ' +
+        'Note: deployments trigger a Cloud Build and can take several minutes to complete.',
+    }
   );
 
   // this is no-op handler is required for mcp-inspector to function due to a mismatch between the SDK mcp-inspector


### PR DESCRIPTION
## Summary

Addresses two related usability issues:

- **Closes #189** — Adds an `instructions` string to the `McpServer` initialization in `mcp-server.js`. MCP clients that support the [2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/schema#initializeresult-instructions) will now receive a brief description of the server's capabilities and a heads-up about deployment duration on first connection.

- **Closes #134** — Adds a step 3 under the Node.js setup guide in `README.md` explaining how to configure a longer MCP client timeout. Cloud Run deployments trigger a Cloud Build that can take several minutes; the default 60-second timeout in some clients (notably Gemini CLI) causes premature disconnects. The README now clarifies that the build continues on GCP even after a disconnect, and shows the Gemini CLI `timeout` config with a 5-minute value.

## Changes

**`mcp-server.js`** — Added `instructions` field to `McpServer` options:
```js
instructions:
  'Use this server to deploy and manage applications on Google Cloud Run. ' +
  'Available tools: deploy source code or file contents to Cloud Run, list services, ' +
  'get service details, and retrieve service logs. ' +
  'Note: deployments trigger a Cloud Build and can take several minutes to complete.',
```

**`README.md`** — Added optional step 3 under "Using Node.js":
> Cloud Run deployments trigger a Cloud Build, which can take several minutes to complete. If your MCP client disconnects with a timeout error before the build finishes, increase the client timeout. The build continues running on GCP even after a client disconnect.

## Test plan

- [ ] Run `npm run test:local` — existing tests should pass unchanged (no logic modified)
- [ ] Run `npx @modelcontextprotocol/inspector node mcp-server.js` and verify the `instructions` field appears in the `InitializeResult` response
- [ ] Review README rendering to confirm the new step reads clearly