### PR TITLE
Add labels to GCS bucket and secrets created by compose

### DIFF
--- a/lib/cloud-api/secrets.js
+++ b/lib/cloud-api/secrets.js
@@ -47,8 +47,8 @@ export async function getSecret(projectId, secretName, accessToken) {
  * @param {string} projectId - GCP project ID.
  * @param {string} secretName - Name of the secret to create.
  * @param {string} accessToken - OAuth2 access token.
- * @param {Function} progressCallback - Progress reporting callback.
  * @param {Object.<string, string>} [labels] - Optional labels to apply to the secret.
+ * @param {Function} progressCallback - Progress reporting callback.
  * @returns {Promise<Object>} The created secret.
  */
 export async function createSecret(

--- a/lib/cloud-api/secrets.js
+++ b/lib/cloud-api/secrets.js
@@ -55,8 +55,8 @@ export async function createSecret(
   projectId,
   secretName,
   accessToken,
-  progressCallback,
-  labels
+  labels,
+  progressCallback
 ) {
   const secretManager = await getSecretManagerClient(projectId, accessToken);
   await logAndProgress(`Creating secret '${secretName}'...`, progressCallback);

--- a/lib/cloud-api/secrets.js
+++ b/lib/cloud-api/secrets.js
@@ -48,24 +48,30 @@ export async function getSecret(projectId, secretName, accessToken) {
  * @param {string} secretName - Name of the secret to create.
  * @param {string} accessToken - OAuth2 access token.
  * @param {Function} progressCallback - Progress reporting callback.
+ * @param {Object.<string, string>} [labels] - Optional labels to apply to the secret.
  * @returns {Promise<Object>} The created secret.
  */
 export async function createSecret(
   projectId,
   secretName,
   accessToken,
-  progressCallback
+  progressCallback,
+  labels
 ) {
   const secretManager = await getSecretManagerClient(projectId, accessToken);
   await logAndProgress(`Creating secret '${secretName}'...`, progressCallback);
+  const secret = {
+    replication: {
+      automatic: {},
+    },
+  };
+  if (labels) {
+    secret.labels = labels;
+  }
   const [res] = await secretManager.createSecret({
     parent: `projects/${projectId}`,
     secretId: secretName,
-    secret: {
-      replication: {
-        automatic: {},
-      },
-    },
+    secret: secret,
   });
   return res;
 }

--- a/lib/cloud-api/storage.js
+++ b/lib/cloud-api/storage.js
@@ -28,6 +28,7 @@ import { logAndProgress } from '../util/helpers.js';
  * @param {string} [location] - The location to create the bucket in if it doesn't exist.
  * @param {string} [accessToken] - Optional access token.
  * @param {function(object): void} [progressCallback] - Optional callback for progress updates.
+ * @param {Object.<string, string>} [labels] - Optional labels to apply to the bucket.
  * @returns {Promise<import('@google-cloud/storage').Bucket>} A promise that resolves with the GCS Bucket object.
  * @throws {Error} If there's an error checking or creating the bucket.
  */
@@ -36,7 +37,8 @@ export async function ensureStorageBucketExists(
   bucketName,
   location,
   accessToken,
-  progressCallback
+  progressCallback,
+  labels
 ) {
   const storage = await getStorageClient(projectId, accessToken);
   const bucket = storage.bucket(bucketName);
@@ -58,8 +60,12 @@ export async function ensureStorageBucketExists(
         progressCallback
       );
       try {
+        const options = { location: location };
+        if (labels) {
+          options.metadata = { labels: labels };
+        }
         const [createdBucket] = await callWithRetry(
-          () => storage.createBucket(bucketName, { location: location }),
+          () => storage.createBucket(bucketName, options),
           `storage.createBucket ${bucketName}`
         );
         await logAndProgress(

--- a/lib/cloud-api/storage.js
+++ b/lib/cloud-api/storage.js
@@ -37,8 +37,8 @@ export async function ensureStorageBucketExists(
   bucketName,
   location,
   accessToken,
-  progressCallback,
-  labels
+  labels,
+  progressCallback
 ) {
   const storage = await getStorageClient(projectId, accessToken);
   const bucket = storage.bucket(bucketName);

--- a/lib/cloud-api/storage.js
+++ b/lib/cloud-api/storage.js
@@ -27,8 +27,8 @@ import { logAndProgress } from '../util/helpers.js';
  * @param {string} bucketName - The name of the storage bucket.
  * @param {string} [location] - The location to create the bucket in if it doesn't exist.
  * @param {string} [accessToken] - Optional access token.
- * @param {function(object): void} [progressCallback] - Optional callback for progress updates.
  * @param {Object.<string, string>} [labels] - Optional labels to apply to the bucket.
+ * @param {function(object): void} [progressCallback] - Optional callback for progress updates.
  * @returns {Promise<import('@google-cloud/storage').Bucket>} A promise that resolves with the GCS Bucket object.
  * @throws {Error} If there's an error checking or creating the bucket.
  */

--- a/lib/deployment/compose.js
+++ b/lib/deployment/compose.js
@@ -29,7 +29,7 @@ import {
   uploadToStorageBucket,
   grantBucketAccess,
 } from '../cloud-api/storage.js';
-import { getProjectNumber } from '../util/helpers.js';
+import { getProjectNumber, sanitizeLabelValue } from '../util/helpers.js';
 import { ensureApisEnabled } from '../cloud-api/helpers.js';
 import {
   getSecret,
@@ -42,6 +42,10 @@ const execFileAsync = util.promisify(execFile);
 
 const RUN_COMPOSE_BIN = 'run-compose';
 const RUN_COMPOSE_VERSION = '1.0.0';
+
+const LABEL_MANAGED_BY = 'managed-by';
+const LABEL_MANAGED_BY_VALUE = 'runcompose';
+const LABEL_PROJECT = 'run-compose-project';
 
 // TODO: Move to production project
 const AR_PROJECT = 'serverless-runtimes-qa';
@@ -293,13 +297,19 @@ export async function composeVolumes(
 
     const computeServiceAccount = `serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`;
 
+    const labels = {
+      [LABEL_MANAGED_BY]: LABEL_MANAGED_BY_VALUE,
+      [LABEL_PROJECT]: sanitizeLabelValue(projectName),
+    };
+
     // Explicitly ensure the bucket exists in the project
     const bucket = await ensureStorageBucketExists(
       projectId,
       bucketName,
       region,
       accessToken,
-      progressCallback
+      progressCallback,
+      labels
     );
 
     await grantBucketAccess(
@@ -439,6 +449,11 @@ export async function composeSecrets(
 
   const projectNumber = await getProjectNumber(projectId, accessToken);
   const computeServiceAccount = `${projectNumber}-compute@developer.gserviceaccount.com`;
+  const projectName = resourcesConfig.project;
+  const labels = {
+    [LABEL_MANAGED_BY]: LABEL_MANAGED_BY_VALUE,
+    [LABEL_PROJECT]: sanitizeLabelValue(projectName),
+  };
 
   const secretEntries = Object.entries(resourcesConfig.secrets);
 
@@ -471,7 +486,8 @@ export async function composeSecrets(
         projectId,
         secretId,
         accessToken,
-        progressCallback
+        progressCallback,
+        labels
       );
     }
 

--- a/lib/deployment/compose.js
+++ b/lib/deployment/compose.js
@@ -301,8 +301,8 @@ export async function composeVolumes(
       bucketName,
       region,
       accessToken,
-      progressCallback,
-      labels
+      labels,
+      progressCallback
     );
 
     await grantBucketAccess(
@@ -479,8 +479,8 @@ export async function composeSecrets(
         projectId,
         secretId,
         accessToken,
-        progressCallback,
-        labels
+        labels,
+        progressCallback
       );
     }
 

--- a/lib/deployment/compose.js
+++ b/lib/deployment/compose.js
@@ -22,7 +22,7 @@ import { execFile } from 'child_process';
 import crypto from 'crypto';
 import { logAndProgress } from '../util/helpers.js';
 import { uploadDirectory } from './helpers.js';
-import { TEMP_PATHS } from './constants.js';
+import { TEMP_PATHS, RUN_COMPOSE } from './constants.js';
 import { ensureRepositoryDownloaded } from '../util/artifacts.js';
 import {
   ensureStorageBucketExists,
@@ -39,13 +39,6 @@ import {
 } from '../cloud-api/secrets.js';
 
 const execFileAsync = util.promisify(execFile);
-
-const RUN_COMPOSE_BIN = 'run-compose';
-const RUN_COMPOSE_VERSION = '1.0.0';
-
-const LABEL_MANAGED_BY = 'managed-by';
-const LABEL_MANAGED_BY_VALUE = 'runcompose';
-const LABEL_PROJECT = 'run-compose-project';
 
 // TODO: Move to production project
 const AR_PROJECT = 'serverless-runtimes-qa';
@@ -113,7 +106,7 @@ export async function runCompose(accessToken, progressCallback) {
   }
 
   const arch = ARCH_MAPPING[key];
-  const binPath = path.join(binDir, RUN_COMPOSE_BIN);
+  const binPath = path.join(binDir, RUN_COMPOSE.BIN);
 
   const binPathResult = await ensureRepositoryDownloaded(
     binPath,
@@ -121,7 +114,7 @@ export async function runCompose(accessToken, progressCallback) {
       project: AR_PROJECT,
       location: AR_LOCATION,
       repository: AR_REPOSITORY,
-      artifactPath: `${arch}:${RUN_COMPOSE_VERSION}:${RUN_COMPOSE_BIN}`,
+      artifactPath: `${arch}:${RUN_COMPOSE.VERSION}:${RUN_COMPOSE.BIN}`,
       displayName: 'run-compose',
     },
     accessToken,
@@ -298,8 +291,8 @@ export async function composeVolumes(
     const computeServiceAccount = `serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`;
 
     const labels = {
-      [LABEL_MANAGED_BY]: LABEL_MANAGED_BY_VALUE,
-      [LABEL_PROJECT]: sanitizeLabelValue(projectName),
+      [RUN_COMPOSE.LABEL_MANAGED_BY]: RUN_COMPOSE.LABEL_MANAGED_BY_VALUE,
+      [RUN_COMPOSE.LABEL_PROJECT]: sanitizeLabelValue(projectName),
     };
 
     // Explicitly ensure the bucket exists in the project
@@ -451,8 +444,8 @@ export async function composeSecrets(
   const computeServiceAccount = `${projectNumber}-compute@developer.gserviceaccount.com`;
   const projectName = resourcesConfig.project;
   const labels = {
-    [LABEL_MANAGED_BY]: LABEL_MANAGED_BY_VALUE,
-    [LABEL_PROJECT]: sanitizeLabelValue(projectName),
+    [RUN_COMPOSE.LABEL_MANAGED_BY]: RUN_COMPOSE.LABEL_MANAGED_BY_VALUE,
+    [RUN_COMPOSE.LABEL_PROJECT]: sanitizeLabelValue(projectName),
   };
 
   const secretEntries = Object.entries(resourcesConfig.secrets);

--- a/lib/deployment/constants.js
+++ b/lib/deployment/constants.js
@@ -55,3 +55,11 @@ export const RUNTIMES = {
 };
 
 export const MAX_ALLOWED_DIRECT_SOURCE_SIZE_BYTES = 250 * 1024 * 1024; // 250 MiB
+
+export const RUN_COMPOSE = {
+  BIN: 'run-compose',
+  VERSION: '1.0.0',
+  LABEL_MANAGED_BY: 'managed-by',
+  LABEL_MANAGED_BY_VALUE: 'runcompose',
+  LABEL_PROJECT: 'run-compose-project',
+};

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -140,3 +140,24 @@ export function sanitizeCloudRunServiceName(name) {
   // Cap at 49 characters (Cloud Run limit is usually 50-63 depending on API, 49 is safe)
   return sanitized.slice(0, 49).replace(/-$/, '');
 }
+
+/**
+ * Sanitizes a string to be a valid GCP label value.
+ * Label values must be:
+ * - <= 63 characters.
+ * - Contain only lowercase letters, numbers, underscores, and dashes.
+ * - Start with a lowercase letter (if not empty).
+ * @param {string} value - The string to sanitize.
+ * @returns {string} A valid GCP label value string.
+ */
+export function sanitizeLabelValue(value) {
+  if (!value) {
+    return '';
+  }
+  let sanitized = value.toLowerCase();
+  sanitized = sanitized.replace(/[^a-z0-9_-]/g, '-');
+  if (!/^[a-z]/.test(sanitized)) {
+    sanitized = 'p-' + sanitized;
+  }
+  return sanitized.slice(0, 63);
+}

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -150,10 +150,14 @@ export function sanitizeCloudRunServiceName(name) {
  * @returns {string} A valid GCP label value string.
  */
 export function sanitizeLabelValue(value) {
-  if (!value) {
+  if (value === undefined || value === null) {
     return '';
   }
-  let sanitized = value.toLowerCase();
+  const stringValue = String(value);
+  if (stringValue === '') {
+    return '';
+  }
+  let sanitized = stringValue.toLowerCase();
   sanitized = sanitized.replace(/[^a-z0-9_-]/g, '-');
   return sanitized.slice(0, 63);
 }

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -146,7 +146,6 @@ export function sanitizeCloudRunServiceName(name) {
  * Label values must be:
  * - <= 63 characters.
  * - Contain only lowercase letters, numbers, underscores, and dashes.
- * - Start with a lowercase letter (if not empty).
  * @param {string} value - The string to sanitize.
  * @returns {string} A valid GCP label value string.
  */
@@ -156,8 +155,5 @@ export function sanitizeLabelValue(value) {
   }
   let sanitized = value.toLowerCase();
   sanitized = sanitized.replace(/[^a-z0-9_-]/g, '-');
-  if (!/^[a-z]/.test(sanitized)) {
-    sanitized = 'p-' + sanitized;
-  }
   return sanitized.slice(0, 63);
 }

--- a/test/local/cloud-api/secrets.test.js
+++ b/test/local/cloud-api/secrets.test.js
@@ -125,6 +125,7 @@ describe('secrets.js', () => {
         projectId,
         secretName,
         accessToken,
+        undefined,
         () => {}
       );
 
@@ -152,8 +153,8 @@ describe('secrets.js', () => {
         projectId,
         secretName,
         accessToken,
-        () => {},
-        labels
+        labels,
+        () => {}
       );
 
       assert.deepEqual(result, mockSecret);

--- a/test/local/cloud-api/secrets.test.js
+++ b/test/local/cloud-api/secrets.test.js
@@ -140,6 +140,35 @@ describe('secrets.js', () => {
         },
       });
     });
+
+    it('should create a secret with labels successfully', async () => {
+      const mockSecret = {
+        name: `projects/${projectId}/secrets/${secretName}`,
+      };
+      createSecretImpl = () => Promise.resolve([mockSecret]);
+      const labels = { key: 'value' };
+
+      const result = await secrets.createSecret(
+        projectId,
+        secretName,
+        accessToken,
+        () => {},
+        labels
+      );
+
+      assert.deepEqual(result, mockSecret);
+      assert.equal(createSecretMock.mock.callCount(), 1);
+      assert.deepEqual(createSecretMock.mock.calls[0].arguments[0], {
+        parent: `projects/${projectId}`,
+        secretId: secretName,
+        secret: {
+          replication: {
+            automatic: {},
+          },
+          labels: labels,
+        },
+      });
+    });
   });
 
   describe('addSecretVersion', () => {

--- a/test/local/cloud-api/storage.test.js
+++ b/test/local/cloud-api/storage.test.js
@@ -108,7 +108,9 @@ describe('Storage API', () => {
         (b) => b.role === 'roles/storage.objectAdmin'
       );
       assert.ok(binding.members.includes('serviceAccount:test@example.com'));
-      assert.ok(binding.members.includes('serviceAccount:existing@example.com'));
+      assert.ok(
+        binding.members.includes('serviceAccount:existing@example.com')
+      );
     });
 
     it('should not call setPolicy if member already has role', async () => {

--- a/test/local/cloud-api/storage.test.js
+++ b/test/local/cloud-api/storage.test.js
@@ -2,19 +2,33 @@ import assert from 'node:assert/strict';
 import { describe, it, mock, beforeEach, afterEach } from 'node:test';
 import esmock from 'esmock';
 
-describe('grantBucketAccess', () => {
+describe('Storage API', () => {
   let storageApi;
   let logAndProgressMock;
   let callWithRetryMock;
+  let getStorageClientMock;
+  let mockStorage;
+  let mockBucket;
 
   beforeEach(async () => {
     logAndProgressMock = mock.fn();
-    // Use the actual path to helpers based on where storage.js is
-    // storage.js is in lib/cloud-api/
-    // util/helpers.js is in lib/util/
-    // cloud-api/helpers.js is in lib/cloud-api/
-
     callWithRetryMock = mock.fn((fn) => fn());
+
+    mockBucket = {
+      name: 'test-bucket',
+      exists: mock.fn(),
+      iam: {
+        getPolicy: mock.fn(),
+        setPolicy: mock.fn(),
+      },
+    };
+
+    mockStorage = {
+      bucket: mock.fn(() => mockBucket),
+      createBucket: mock.fn(),
+    };
+
+    getStorageClientMock = mock.fn(() => Promise.resolve(mockStorage));
 
     storageApi = await esmock('../../../lib/cloud-api/storage.js', {
       '../../../lib/util/helpers.js': {
@@ -23,6 +37,9 @@ describe('grantBucketAccess', () => {
       '../../../lib/cloud-api/helpers.js': {
         callWithRetry: callWithRetryMock,
       },
+      '../../../lib/clients.js': {
+        getStorageClient: getStorageClientMock,
+      },
     });
   });
 
@@ -30,125 +47,184 @@ describe('grantBucketAccess', () => {
     mock.restoreAll();
   });
 
-  it('should grant access if member does not have role', async () => {
-    const mockBucket = {
-      name: 'test-bucket',
-      iam: {
-        getPolicy: mock.fn(() => Promise.resolve([{ bindings: [] }])),
-        setPolicy: mock.fn(() => Promise.resolve()),
-      },
-    };
+  describe('grantBucketAccess', () => {
+    it('should grant access if member does not have role', async () => {
+      const testBucket = {
+        name: 'test-bucket',
+        iam: {
+          getPolicy: mock.fn(() => Promise.resolve([{ bindings: [] }])),
+          setPolicy: mock.fn(() => Promise.resolve()),
+        },
+      };
 
-    await storageApi.grantBucketAccess(
-      mockBucket,
-      'roles/storage.objectAdmin',
-      'serviceAccount:test@example.com'
-    );
+      await storageApi.grantBucketAccess(
+        testBucket,
+        'roles/storage.objectAdmin',
+        'serviceAccount:test@example.com'
+      );
 
-    // Should call getPolicy once
-    assert.strictEqual(mockBucket.iam.getPolicy.mock.callCount(), 1);
-    // Should call setPolicy once
-    assert.strictEqual(mockBucket.iam.setPolicy.mock.callCount(), 1);
+      assert.strictEqual(testBucket.iam.getPolicy.mock.callCount(), 1);
+      assert.strictEqual(testBucket.iam.setPolicy.mock.callCount(), 1);
 
-    // Verify the binding was added
-    const setPolicyCall = mockBucket.iam.setPolicy.mock.calls[0];
-    const updatedPolicy = setPolicyCall.arguments[0];
-    assert.deepStrictEqual(updatedPolicy.bindings, [
-      {
-        role: 'roles/storage.objectAdmin',
-        members: ['serviceAccount:test@example.com'],
-      },
-    ]);
+      const setPolicyCall = testBucket.iam.setPolicy.mock.calls[0];
+      const updatedPolicy = setPolicyCall.arguments[0];
+      assert.deepStrictEqual(updatedPolicy.bindings, [
+        {
+          role: 'roles/storage.objectAdmin',
+          members: ['serviceAccount:test@example.com'],
+        },
+      ]);
+    });
+
+    it('should add to existing role bindings if role exists but member is missing', async () => {
+      const testBucket = {
+        name: 'test-bucket',
+        iam: {
+          getPolicy: mock.fn(() =>
+            Promise.resolve([
+              {
+                bindings: [
+                  {
+                    role: 'roles/storage.objectAdmin',
+                    members: ['serviceAccount:existing@example.com'],
+                  },
+                ],
+              },
+            ])
+          ),
+          setPolicy: mock.fn(() => Promise.resolve()),
+        },
+      };
+
+      await storageApi.grantBucketAccess(
+        testBucket,
+        'roles/storage.objectAdmin',
+        'serviceAccount:test@example.com'
+      );
+
+      assert.strictEqual(testBucket.iam.setPolicy.mock.callCount(), 1);
+      const updatedPolicy = testBucket.iam.setPolicy.mock.calls[0].arguments[0];
+      const binding = updatedPolicy.bindings.find(
+        (b) => b.role === 'roles/storage.objectAdmin'
+      );
+      assert.ok(binding.members.includes('serviceAccount:test@example.com'));
+      assert.ok(binding.members.includes('serviceAccount:existing@example.com'));
+    });
+
+    it('should not call setPolicy if member already has role', async () => {
+      const testBucket = {
+        name: 'test-bucket',
+        iam: {
+          getPolicy: mock.fn(() =>
+            Promise.resolve([
+              {
+                bindings: [
+                  {
+                    role: 'roles/storage.objectAdmin',
+                    members: ['serviceAccount:test@example.com'],
+                  },
+                ],
+              },
+            ])
+          ),
+          setPolicy: mock.fn(() => Promise.resolve()),
+        },
+      };
+
+      await storageApi.grantBucketAccess(
+        testBucket,
+        'roles/storage.objectAdmin',
+        'serviceAccount:test@example.com'
+      );
+
+      assert.strictEqual(testBucket.iam.getPolicy.mock.callCount(), 1);
+      assert.strictEqual(testBucket.iam.setPolicy.mock.callCount(), 0);
+    });
+
+    it('should handle errors gracefully by logging a warning instead of throwing', async () => {
+      const testBucket = {
+        name: 'test-bucket',
+        iam: {
+          getPolicy: mock.fn(() =>
+            Promise.reject(new Error('IAM Permission Denied'))
+          ),
+          setPolicy: mock.fn(),
+        },
+      };
+
+      await storageApi.grantBucketAccess(
+        testBucket,
+        'roles/storage.objectAdmin',
+        'serviceAccount:test@example.com'
+      );
+
+      const errorLogs = logAndProgressMock.mock.calls.filter(
+        (c) => c.arguments[2] === 'warn'
+      );
+      assert.ok(errorLogs.length > 0);
+      assert.ok(errorLogs[0].arguments[0].includes('IAM Permission Denied'));
+    });
   });
 
-  it('should add to existing role bindings if role exists but member is missing', async () => {
-    const mockBucket = {
-      name: 'test-bucket',
-      iam: {
-        getPolicy: mock.fn(() =>
-          Promise.resolve([
-            {
-              bindings: [
-                {
-                  role: 'roles/storage.objectAdmin',
-                  members: ['serviceAccount:existing@example.com'],
-                },
-              ],
-            },
-          ])
-        ),
-        setPolicy: mock.fn(() => Promise.resolve()),
-      },
-    };
+  describe('ensureStorageBucketExists', () => {
+    it('should return bucket if it already exists', async () => {
+      mockBucket.exists.mock.mockImplementation(() => Promise.resolve([true]));
 
-    await storageApi.grantBucketAccess(
-      mockBucket,
-      'roles/storage.objectAdmin',
-      'serviceAccount:test@example.com'
-    );
+      const result = await storageApi.ensureStorageBucketExists(
+        'test-project',
+        'test-bucket',
+        'us-central1',
+        'token'
+      );
 
-    assert.strictEqual(mockBucket.iam.setPolicy.mock.callCount(), 1);
-    const updatedPolicy = mockBucket.iam.setPolicy.mock.calls[0].arguments[0];
-    const binding = updatedPolicy.bindings.find(
-      (b) => b.role === 'roles/storage.objectAdmin'
-    );
-    assert.ok(binding.members.includes('serviceAccount:test@example.com'));
-    assert.ok(binding.members.includes('serviceAccount:existing@example.com'));
-  });
+      assert.strictEqual(result, mockBucket);
+      assert.strictEqual(mockStorage.createBucket.mock.callCount(), 0);
+    });
 
-  it('should not call setPolicy if member already has role', async () => {
-    const mockBucket = {
-      name: 'test-bucket',
-      iam: {
-        getPolicy: mock.fn(() =>
-          Promise.resolve([
-            {
-              bindings: [
-                {
-                  role: 'roles/storage.objectAdmin',
-                  members: ['serviceAccount:test@example.com'],
-                },
-              ],
-            },
-          ])
-        ),
-        setPolicy: mock.fn(() => Promise.resolve()),
-      },
-    };
+    it('should create bucket without labels if none provided', async () => {
+      mockBucket.exists.mock.mockImplementation(() => Promise.resolve([false]));
+      mockStorage.createBucket.mock.mockImplementation((name, options) =>
+        Promise.resolve([mockBucket])
+      );
 
-    await storageApi.grantBucketAccess(
-      mockBucket,
-      'roles/storage.objectAdmin',
-      'serviceAccount:test@example.com'
-    );
+      const result = await storageApi.ensureStorageBucketExists(
+        'test-project',
+        'test-bucket',
+        'us-central1',
+        'token'
+      );
 
-    assert.strictEqual(mockBucket.iam.getPolicy.mock.callCount(), 1);
-    assert.strictEqual(mockBucket.iam.setPolicy.mock.callCount(), 0);
-  });
+      assert.strictEqual(result, mockBucket);
+      assert.strictEqual(mockStorage.createBucket.mock.callCount(), 1);
+      const call = mockStorage.createBucket.mock.calls[0];
+      assert.strictEqual(call.arguments[0], 'test-bucket');
+      assert.deepStrictEqual(call.arguments[1], { location: 'us-central1' });
+    });
 
-  it('should handle errors gracefully by logging a warning instead of throwing', async () => {
-    const mockBucket = {
-      name: 'test-bucket',
-      iam: {
-        getPolicy: mock.fn(() =>
-          Promise.reject(new Error('IAM Permission Denied'))
-        ),
-        setPolicy: mock.fn(),
-      },
-    };
+    it('should create bucket with labels if provided', async () => {
+      mockBucket.exists.mock.mockImplementation(() => Promise.resolve([false]));
+      mockStorage.createBucket.mock.mockImplementation((name, options) =>
+        Promise.resolve([mockBucket])
+      );
 
-    // This should not throw
-    await storageApi.grantBucketAccess(
-      mockBucket,
-      'roles/storage.objectAdmin',
-      'serviceAccount:test@example.com'
-    );
+      const labels = { key: 'value' };
+      const result = await storageApi.ensureStorageBucketExists(
+        'test-project',
+        'test-bucket',
+        'us-central1',
+        'token',
+        undefined,
+        labels
+      );
 
-    // Verify warning was logged
-    const errorLogs = logAndProgressMock.mock.calls.filter(
-      (c) => c.arguments[2] === 'warn'
-    );
-    assert.ok(errorLogs.length > 0);
-    assert.ok(errorLogs[0].arguments[0].includes('IAM Permission Denied'));
+      assert.strictEqual(result, mockBucket);
+      assert.strictEqual(mockStorage.createBucket.mock.callCount(), 1);
+      const call = mockStorage.createBucket.mock.calls[0];
+      assert.strictEqual(call.arguments[0], 'test-bucket');
+      assert.deepStrictEqual(call.arguments[1], {
+        location: 'us-central1',
+        metadata: { labels: labels },
+      });
+    });
   });
 });

--- a/test/local/cloud-api/storage.test.js
+++ b/test/local/cloud-api/storage.test.js
@@ -215,8 +215,8 @@ describe('Storage API', () => {
         'test-bucket',
         'us-central1',
         'token',
-        undefined,
-        labels
+        labels,
+        undefined
       );
 
       assert.strictEqual(result, mockBucket);

--- a/test/local/compose.test.js
+++ b/test/local/compose.test.js
@@ -418,7 +418,7 @@ describe('Compose Deployment', () => {
       // Called once in composeVolumes
       assert.strictEqual(ensureStorageBucketExistsMock.mock.callCount(), 1);
       const call = ensureStorageBucketExistsMock.mock.calls[0];
-      assert.deepStrictEqual(call.arguments[5], {
+      assert.deepStrictEqual(call.arguments[4], {
         'managed-by': 'runcompose',
         'run-compose-project': 'my-project',
       });
@@ -485,7 +485,7 @@ describe('Compose Deployment', () => {
       assert.ok(
         bucketName.startsWith('987654321-my-project-us-central1-compose')
       );
-      assert.deepStrictEqual(calls[0].arguments[5], {
+      assert.deepStrictEqual(calls[0].arguments[4], {
         'managed-by': 'runcompose',
         'run-compose-project': 'my-project',
       });
@@ -578,7 +578,7 @@ describe('Compose Deployment', () => {
       assert.strictEqual(ensureApisEnabledMock.mock.callCount(), 1);
       assert.strictEqual(createSecretMock.mock.callCount(), 1);
       const call = createSecretMock.mock.calls[0];
-      assert.deepStrictEqual(call.arguments[4], {
+      assert.deepStrictEqual(call.arguments[3], {
         'managed-by': 'runcompose',
         'run-compose-project': 'my-project',
       });

--- a/test/local/compose.test.js
+++ b/test/local/compose.test.js
@@ -417,6 +417,11 @@ describe('Compose Deployment', () => {
       assert.strictEqual(uploadDirectoryMock.mock.callCount(), 1);
       // Called once in composeVolumes
       assert.strictEqual(ensureStorageBucketExistsMock.mock.callCount(), 1);
+      const call = ensureStorageBucketExistsMock.mock.calls[0];
+      assert.deepStrictEqual(call.arguments[5], {
+        'managed-by': 'runcompose',
+        'run-compose-project': 'my-project',
+      });
       assert.strictEqual(grantBucketAccessMock.mock.callCount(), 1);
       // Called once in composeVolumes (reused in handleBindMounts)
       assert.strictEqual(getProjectNumberMock.mock.callCount(), 1);
@@ -480,6 +485,10 @@ describe('Compose Deployment', () => {
       assert.ok(
         bucketName.startsWith('987654321-my-project-us-central1-compose')
       );
+      assert.deepStrictEqual(calls[0].arguments[5], {
+        'managed-by': 'runcompose',
+        'run-compose-project': 'my-project',
+      });
     });
   });
 
@@ -568,6 +577,11 @@ describe('Compose Deployment', () => {
       );
       assert.strictEqual(ensureApisEnabledMock.mock.callCount(), 1);
       assert.strictEqual(createSecretMock.mock.callCount(), 1);
+      const call = createSecretMock.mock.calls[0];
+      assert.deepStrictEqual(call.arguments[4], {
+        'managed-by': 'runcompose',
+        'run-compose-project': 'my-project',
+      });
       assert.strictEqual(addSecretVersionMock.mock.callCount(), 1);
       assert.strictEqual(addSecretAccessorBindingMock.mock.callCount(), 1);
     });

--- a/test/local/util.test.js
+++ b/test/local/util.test.js
@@ -338,6 +338,8 @@ describe('Utility Helpers', () => {
       const { sanitizeLabelValue } = await import('../../lib/util/helpers.js');
 
       assert.equal(sanitizeLabelValue(''), '');
+      assert.equal(sanitizeLabelValue(null), '');
+      assert.equal(sanitizeLabelValue(undefined), '');
       assert.equal(sanitizeLabelValue('valid-label'), 'valid-label');
       assert.equal(sanitizeLabelValue('Upper-Case'), 'upper-case');
       assert.equal(sanitizeLabelValue('invalid@char'), 'invalid-char');
@@ -350,6 +352,10 @@ describe('Utility Helpers', () => {
         '-starts-with-dash'
       );
       assert.equal(sanitizeLabelValue('a'.repeat(70)), 'a'.repeat(63));
+      assert.equal(sanitizeLabelValue(12345), '12345');
+      assert.equal(sanitizeLabelValue(0), '0');
+      assert.equal(sanitizeLabelValue(true), 'true');
+      assert.equal(sanitizeLabelValue(false), 'false');
     });
   });
 });

--- a/test/local/util.test.js
+++ b/test/local/util.test.js
@@ -343,11 +343,11 @@ describe('Utility Helpers', () => {
       assert.equal(sanitizeLabelValue('invalid@char'), 'invalid-char');
       assert.equal(
         sanitizeLabelValue('1starts-with-number'),
-        'p-1starts-with-number'
+        '1starts-with-number'
       );
       assert.equal(
         sanitizeLabelValue('-starts-with-dash'),
-        'p--starts-with-dash'
+        '-starts-with-dash'
       );
       assert.equal(sanitizeLabelValue('a'.repeat(70)), 'a'.repeat(63));
     });

--- a/test/local/util.test.js
+++ b/test/local/util.test.js
@@ -341,8 +341,14 @@ describe('Utility Helpers', () => {
       assert.equal(sanitizeLabelValue('valid-label'), 'valid-label');
       assert.equal(sanitizeLabelValue('Upper-Case'), 'upper-case');
       assert.equal(sanitizeLabelValue('invalid@char'), 'invalid-char');
-      assert.equal(sanitizeLabelValue('1starts-with-number'), 'p-1starts-with-number');
-      assert.equal(sanitizeLabelValue('-starts-with-dash'), 'p--starts-with-dash');
+      assert.equal(
+        sanitizeLabelValue('1starts-with-number'),
+        'p-1starts-with-number'
+      );
+      assert.equal(
+        sanitizeLabelValue('-starts-with-dash'),
+        'p--starts-with-dash'
+      );
       assert.equal(sanitizeLabelValue('a'.repeat(70)), 'a'.repeat(63));
     });
   });

--- a/test/local/util.test.js
+++ b/test/local/util.test.js
@@ -332,4 +332,18 @@ describe('Utility Helpers', () => {
       );
     });
   });
+
+  describe('sanitizeLabelValue', () => {
+    test('sanitizes various inputs correctly', async () => {
+      const { sanitizeLabelValue } = await import('../../lib/util/helpers.js');
+
+      assert.equal(sanitizeLabelValue(''), '');
+      assert.equal(sanitizeLabelValue('valid-label'), 'valid-label');
+      assert.equal(sanitizeLabelValue('Upper-Case'), 'upper-case');
+      assert.equal(sanitizeLabelValue('invalid@char'), 'invalid-char');
+      assert.equal(sanitizeLabelValue('1starts-with-number'), 'p-1starts-with-number');
+      assert.equal(sanitizeLabelValue('-starts-with-dash'), 'p--starts-with-dash');
+      assert.equal(sanitizeLabelValue('a'.repeat(70)), 'a'.repeat(63));
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces labels to Google Cloud Storage (GCS) buckets and Secret Manager secrets created during Cloud Run Compose deployments. This aligns the MCP server's behavior with gcloud run compose to help track and identify resources associated with specific compose projects.